### PR TITLE
Fix for issue #81, check currency before get price

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -160,7 +160,11 @@ if (is_plugin_active('woocommerce/woocommerce.php') || class_exists('WooCommerce
 
                 $blockonomics = new Blockonomics;
                 $responseObj = $blockonomics->new_address(get_option('blockonomics_api_key'), get_option("blockonomics_callback_secret"));
-                $price = $blockonomics->get_price(get_woocommerce_currency());
+                if(get_woocommerce_currency() != 'BTC'){
+                	$price = $blockonomics->get_price(get_woocommerce_currency());
+                }else{
+                	$price = 1;
+                }
 
                 if($responseObj->response_code != 'HTTP/1.1 200 OK') {
                     $this->displayError($woocommerce);


### PR DESCRIPTION
Fix for issue [#81](https://github.com/blockonomics/woocommerce-plugin/issues/81), check Woocommerce currency before fetching the price