### PR TITLE
Fix order_key for all woocommerce versions, issue #161

### DIFF
--- a/php/WC_Gateway_Blockonomics.php
+++ b/php/WC_Gateway_Blockonomics.php
@@ -105,7 +105,8 @@ class WC_Gateway_Blockonomics extends WC_Payment_Gateway
         $cancel_url = $order->get_cancel_order_url_raw();
         $cancel_url = add_query_arg('return_from_blockonomics', true, $cancel_url);
         $cancel_url = add_query_arg('cancelled', true, $cancel_url);
-        $cancel_url = add_query_arg('order_key', $order->get_order_key(), $cancel_url);
+        $order_key = method_exists( $order, 'get_order_key' ) ? $order->get_order_key() : $order->order_key;
+        $cancel_url = add_query_arg('order_key', $order_key, $cancel_url);
 
         $blockonomics = new Blockonomics;
         $responseObj = $blockonomics->new_address(get_option("blockonomics_callback_secret"));


### PR DESCRIPTION
Fix order_key for previous woocommerce versions < 3, issue #161