### PR TITLE
Fixed callback Issues

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -81,17 +81,23 @@ function CheckoutController($scope, $interval, Order, $timeout, Url) {
             }
             $scope.tick_interval = $interval($scope.tick, 1000);
             //Connect and Listen on websocket for payment notification
-            var ws = new ReconnectingWebSocket("wss://" + subdomain + ".blockonomics.co/payment/" + $scope.order.address + "?timestamp=" + $scope.order.timestamp);
+            var ws = new ReconnectingWebSocket("wss://" + subdomain + ".blockonomics.co/payment/" + $scope.order.address);
             ws.onmessage = function(evt) {
                 ws.close();
                 $interval(function() {
-                    //Redirect to order received page if message from socket
+                    //Redirect to order confirmation page if message from socket
                     window.location = Url.get_wc_endpoint({'finish_order' : $scope.order_id});
                 //Wait for 2 seconds for order status to update on server
                 }, 2000, 1);
             }
         }
+        else if ($scope.order.status >= 0){
+          //Goto order confirmation as payment is already in process or done
+          window.location = Url.get_wc_endpoint({'finish_order' : $scope.order_id});
+        }
+
     }
+
     
     //Check if the blockonomics order is present
     function check_blockonomics_order() {

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -575,9 +575,10 @@ class Blockonomics
 
         if ( !$this->is_payment_recorded($status, $order, $wc_order) )  {
             $this->record_payment($value, $order, $wc_order);
-            $order['status'] = $this->check_paid_amount($status, $value, $order, $wc_order);
+            $status = $this->check_paid_amount($status, $value, $order, $wc_order);
             $this->update_temp_draw_amount($value);
         }
+        $order['status'] = $status;
         $orders[$order['order_id']][$address] = $order;
         update_option('blockonomics_orders', $orders);
     }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -540,25 +540,18 @@ class Blockonomics
 
     // Check for underpayment, overpayment or correct amount
     public function check_paid_amount($status, $value, $order, $wc_order){
-        if ($order['satoshi'] > $value) {
-            //Check underpayment slack
-            $underpayment_slack = get_option("blockonomics_underpayment_slack", 0)/100 * $order['satoshi'];
-            if ($order['satoshi'] - $underpayment_slack > $value) {
-                $status = -2; //Payment error , amount not matching
-                $wc_order->update_status('failed', __('Paid amount less than expected.', 'blockonomics-bitcoin-payments'));
-            }else{
-                $wc_order->add_order_note(__('Payment completed', 'blockonomics-bitcoin-payments'));
-                $wc_order->payment_complete($order['txid']);
-            }
-        }
-        else{
-            if ($order['satoshi'] < $value) {
-                $wc_order->add_order_note(__( 'Paid amount more than expected.', 'blockonomics-bitcoin-payments' ));
-            }
-            $wc_order->add_order_note(__('Payment completed', 'blockonomics-bitcoin-payments'));
-            $wc_order->payment_complete($order['txid']);
-        }
-        return $status;
+      $underpayment_slack = get_option("blockonomics_underpayment_slack", 0)/100 * $order['satoshi'];
+      if ($order['satoshi'] - $underpayment_slack > $value) {
+        $status = -2; //Payment error , amount less than expected 
+        $wc_order->update_status('failed', __('Paid amount less than expected.', 'blockonomics-bitcoin-payments'));
+      }else{
+        $wc_order->add_order_note(__('Payment completed', 'blockonomics-bitcoin-payments'));
+        $wc_order->payment_complete($order['txid']);
+      }
+      if ($order['satoshi'] < $value) {
+        $wc_order->add_order_note(__( 'Paid amount more than expected.', 'blockonomics-bitcoin-payments' ));
+      }
+      return $status;
     }
 
     // Keep track of funds in temp wallet
@@ -576,18 +569,16 @@ class Blockonomics
         
         $order = $this->get_order_by_address($address);
         $wc_order = new WC_Order($order['order_id']);
+        
+        $order['txid'] = $txid;
+
 
         if ( !$this->is_payment_recorded($status, $order, $wc_order) )  {
             $this->record_payment($value, $order, $wc_order);
-            $status = $this->check_paid_amount($status, $value, $order, $wc_order);
-
+            $order['status'] = $this->check_paid_amount($status, $value, $order, $wc_order);
             $this->update_temp_draw_amount($value);
         }
-
-        $order['txid'] = $txid;
-        $order['status'] = $status;
-        $orders[$order_id][$address] = $order;
-
+        $orders[$order['order_id']][$address] = $order;
         update_option('blockonomics_orders', $orders);
     }
 }

--- a/templates/blockonomics_checkout.php
+++ b/templates/blockonomics_checkout.php
@@ -41,7 +41,7 @@ $blockonomics = new Blockonomics;
       </div>
       <!-- Payment Error -->
       <div class="bnomics-order-error-wrapper" ng-show="order.status == -2" ng-cloak>
-        <h3 class="warning bnomics-status-warning"><?=__('Payment Error', 'blockonomics-bitcoin-payments')?></h3>
+        <h3 class="warning bnomics-status-warning"><?=__('Paid order BTC amount is less than expected. Contact merchant', 'blockonomics-bitcoin-payments')?></h3>
       </div>
       <!-- Blockonomics Checkout Panel -->
       <div class="bnomics-order-panel" ng-show="order.status == -1" ng-cloak>


### PR DESCRIPTION
- order txid was not set before called record_payment method resulting in error. See screenshot
- simplified callback value compare logic
- In client, redirecting to order confirmation if status received indicates a successful transaction. Sometimes websocket may not work due to network disconnection or other issues. So UI wise it is preferable that refershing the page results in same behviour 
- Removed timestamp from websocket call to fix issues mentioned in https://github.com/blockonomics/woocommerce-plugin/pull/201

![Screenshot from 2020-08-29 00-39-01](https://user-images.githubusercontent.com/737092/91612166-7aa39e00-e99a-11ea-8bb6-d74c3ce0a031.png)
