### PR TITLE
Fixing database error

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -495,7 +495,7 @@ function blockonomics_create_table() {
 
     $table_name = $wpdb->prefix . 'blockonomics_orders';
     $charset_collate = $wpdb->get_charset_collate();
-    $sql = "CREATE TABLE IF NOT EXISTS $table_name (
+    $sql = "CREATE TABLE $table_name (
         order_id int NOT NULL,
         status int NOT NULL,
         crypto varchar(3) NOT NULL,
@@ -535,7 +535,7 @@ function blockonomics_update_db_check() {
         // if ($installed_ver < 1.0) {
         //     $wpdb->query("ALTER TABLE $table_name DROP transaction;");
         // }
-        update_option( 'blockonomics_db_version', $blockonomics_db_version );
+        blockonomics_create_table();
     }
 }
 

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -530,17 +530,20 @@ function blockonomics_update_db_check() {
     global $blockonomics_db_version;
 
     $installed_ver = get_site_option( 'blockonomics_db_version' );
-    if ( $installed_ver != $blockonomics_db_version ) {
+    if (!$installed_ver) {
+        blockonomics_create_table();
+    }else if ( $installed_ver != $blockonomics_db_version ) {
+
         // Example function to demonstrate table changes between upgrade versions
         // if ($installed_ver < 1.0) {
         //     $wpdb->query("ALTER TABLE $table_name DROP transaction;");
         // }
-        blockonomics_create_table();
-    }
-}
 
+        update_option( 'blockonomics_db_version', $blockonomics_db_version );
+    }
+    
+}
 add_action( 'plugins_loaded', 'blockonomics_update_db_check' );
-register_activation_hook( __FILE__, 'blockonomics_create_table' );
 
 //Show message when plugin is activated
 function blockonomics_plugin_activation() {

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -512,7 +512,7 @@ function blockonomics_create_table() {
     require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
     dbDelta( $sql );
 
-    add_option( 'blockonomics_db_version', $blockonomics_db_version );
+    update_option( 'blockonomics_db_version', $blockonomics_db_version );
 }
 
 function blockonomics_activation_hook() {

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -512,7 +512,7 @@ function blockonomics_create_table() {
     require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
     dbDelta( $sql );
 
-    update_option( 'blockonomics_db_version', $blockonomics_db_version );
+    add_option( 'blockonomics_db_version', $blockonomics_db_version );
 }
 
 function blockonomics_activation_hook() {
@@ -530,20 +530,17 @@ function blockonomics_update_db_check() {
     global $blockonomics_db_version;
 
     $installed_ver = get_site_option( 'blockonomics_db_version' );
-    if (!$installed_ver) {
-        blockonomics_create_table();
-    }else if ( $installed_ver != $blockonomics_db_version ) {
-
+    if ( $installed_ver != $blockonomics_db_version ) {
         // Example function to demonstrate table changes between upgrade versions
         // if ($installed_ver < 1.0) {
         //     $wpdb->query("ALTER TABLE $table_name DROP transaction;");
         // }
-
         update_option( 'blockonomics_db_version', $blockonomics_db_version );
     }
-    
 }
+
 add_action( 'plugins_loaded', 'blockonomics_update_db_check' );
+register_activation_hook( __FILE__, 'blockonomics_create_table' );
 
 //Show message when plugin is activated
 function blockonomics_plugin_activation() {

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -530,20 +530,17 @@ function blockonomics_update_db_check() {
     global $blockonomics_db_version;
 
     $installed_ver = get_site_option( 'blockonomics_db_version' );
-    if (!$installed_ver) {
-        blockonomics_create_table();
-    }else if ( $installed_ver != $blockonomics_db_version ) {
-
+    if ( $installed_ver != $blockonomics_db_version ) {
         // Example function to demonstrate table changes between upgrade versions
         // if ($installed_ver < 1.0) {
         //     $wpdb->query("ALTER TABLE $table_name DROP transaction;");
         // }
-
-        update_option( 'blockonomics_db_version', $blockonomics_db_version );
+        blockonomics_create_table();
     }
-    
 }
+
 add_action( 'plugins_loaded', 'blockonomics_update_db_check' );
+register_activation_hook( __FILE__, 'blockonomics_create_table' );
 
 //Show message when plugin is activated
 function blockonomics_plugin_activation() {


### PR DESCRIPTION
This PR is created to fix [this error](https://wordpress.org/support/topic/showing-sql-error-from-query-monitor/#post-14285132). I was able to recreate the error and has done some small changes in order to fix it.

There are mainly two things that have changed. The register_activation_hook() has been introduced. It is true that this is not called during an update. However, it seems to be necessary during plugin initiation. 

$sql _CREATE TABLE IF NOT EXISTS_ has been changed to _CREATE TABLE_. This is the way it is structured in the [WordPress documentation](https://codex.wordpress.org/Creating_Tables_with_Plugins). It seems to be the case that dbDelta() does not require _IF NOT EXISTS_, but will instead discern this itself.

As part of testing I've deleted, installed, upgraded the database, with and without orders. It seems to work as it should,

Please review this PR. 