### PR TITLE
Simplify callback logic

### DIFF
--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -157,15 +157,15 @@ class Blockonomics
             $server_callback_url = isset($one_response->callback) ? $one_response->callback : '';
             $server_base_url = preg_replace('/https?:\/\//', '', $server_callback_url);
             $xpub = isset($one_response->address) ? $one_response->address : '';
-            // No callback
             if(!$server_callback_url){
+                // No callback
                 $available_xpub = $xpub;
-            // Exact match
             }else if($server_callback_url == $wordpress_callback_url){
+                // Exact match
                 return '';
             }
-            // Partial Match - Only secret or protocol differ
             else if(strpos($server_callback_url, $api_url) === 0 || strpos($server_base_url, $base_url) === 0 ){
+                // Partial Match - Only secret or protocol differ
                 $this->update_callback($wordpress_callback_url, $crypto, $xpub);
                 return '';
             }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -131,9 +131,7 @@ class Blockonomics
     public function check_get_callbacks_response_body ($response, $crypto){
         $error_str = '';
         $response_body = json_decode(wp_remote_retrieve_body($response));
-        $callback_secret = get_option('blockonomics_callback_secret');
-        $api_url = WC()->api_request_url('WC_Gateway_Blockonomics');
-        $wordpress_callback_url = add_query_arg('secret', $callback_secret, $api_url);
+
         //if merchant doesn't have any xPubs on his Blockonomics account
         if (!isset($response_body) || count($response_body) == 0)
         {
@@ -142,14 +140,17 @@ class Blockonomics
         //if merchant has at least one xPub on his Blockonomics account
         elseif (count($response_body) >= 1)
         {
-            $error_str = $this->examine_server_callback_urls($response_body, $wordpress_callback_url, $api_url, $crypto);
+            $error_str = $this->examine_server_callback_urls($response_body, $crypto);
         }
         return $error_str;
     }
 
     // checks each existing xpub callback URL to update and/or use
-    public function examine_server_callback_urls($response_body, $wordpress_callback_url, $api_url, $crypto)
+    public function examine_server_callback_urls($response_body, $crypto)
     {
+        $callback_secret = get_option('blockonomics_callback_secret');
+        $api_url = WC()->api_request_url('WC_Gateway_Blockonomics');
+        $wordpress_callback_url = add_query_arg('secret', $callback_secret, $api_url);
         $base_url = preg_replace('/https?:\/\//', '', $api_url);
         $available_xpub = '';
         $partial_match = '';

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -173,7 +173,6 @@ class Blockonomics
             }
             //if there's an exact match but the protocols are different => store values and only update as last resort
             else if(strpos($server_callback_url, $base_url)){
-                echo 'server: ' . $server_callback_url;
                 $different_protocols = true;
                 $different_protocol_xpub = $xpub;
             }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -139,17 +139,22 @@ class Blockonomics
         {
             $response_callback = '';
             $xpub = '';
-            if(isset($response_body[0])){
-                $response_callback = isset($response_body[0]->callback) ? $response_body[0]->callback : '';
-                $xpub = isset($response_body[0]->address) ? $response_body[0]->address : '';
-            }
             $callback_secret = get_option('blockonomics_callback_secret');
             $api_url = WC()->api_request_url('WC_Gateway_Blockonomics');
             $callback_url = add_query_arg('secret', $callback_secret, $api_url);
             $base_url = get_bloginfo('wpurl');
             $base_url = preg_replace('/https?:\/\//', '', $base_url);
+            if(isset($response_body[0])){
+                $response_callback = isset($response_body[0]->callback) ? $response_body[0]->callback : '';
+                $xpub = isset($response_body[0]->address) ? $response_body[0]->address : '';
+            }
+            //Check if there's a callback on the server
+            if(!$response_callback || $response_callback == null)
+            {
+                //No callback URL set, set one 
+                $this->update_callback($callback_url, $crypto, $xpub);
             //Compare Server and WP callback
-            if ($response_callback == $callback_url) {
+            } elseif ($response_callback == $callback_url) {
                 //Exact match => No changes required
             } elseif (strpos($response_callback, $base_url)){
                 //Domains have exact match but other details are different => replace callback 

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -152,6 +152,7 @@ class Blockonomics
     {
         $base_url = preg_replace('/https?:\/\//', '', $api_url);
         $available_xpub = '';
+        $partial_match = '';
         //Go through all xpubs on the server and examine their callback url
         foreach($response_body as $one_response){
             $server_callback_url = isset($one_response->callback) ? $one_response->callback : '';
@@ -166,13 +167,13 @@ class Blockonomics
             }
             else if(strpos($server_callback_url, $api_url) === 0 || strpos($server_base_url, $base_url) === 0 ){
                 // Partial Match - Only secret or protocol differ
-                $this->update_callback($wordpress_callback_url, $crypto, $xpub);
-                return '';
+                $partial_match = $xpub;
             }
         }
         // Use the available xpub
-        if($available_xpub){
-            $this->update_callback($wordpress_callback_url, $crypto, $available_xpub);
+        if($partial_match || $available_xpub){
+            $update_xpub = $partial_match ? $partial_match : $available_xpub;
+            $this->update_callback($wordpress_callback_url, $crypto, $update_xpub);
             return '';
         }
         // No match and no empty callback

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -149,11 +149,11 @@ class Blockonomics
 
     public function examine_server_callback_urls($response_body, $wordpress_callback_url, $api_url, $crypto)
     {
-        //Scenario 1: Exact match => return $error_str;
-        //Scenario 2: All but secret matches => update_callback(), then return $error_str;
-        //Scenario 3: if scenario 1 and 2 failed; Use an empty callback, if present.
-        //Scenario 4: if scenario 1, 2, and 3 failed; Use matching callback with different protocol, if present.
-        //Scenario 5: All above failed => Multiple callback error: Please add a new store with valid xpub
+        //Scenario 1: Exact match                       =>      return $error_str;
+        //Scenario 2: All but secret matches            =>      update_callback(), then return $error_str;
+        //Scenario 3: Scenario 1 and 2 failed           =>      Use an empty callback, if present.
+        //Scenario 4: Scenario 1, 2, and 3 failed       =>      Use matching callback with different protocol, if present.
+        //Scenario 5: All above failed                  =>      Multiple callback error: Please add a new store with valid xpub
 
         //prepare variables
         $base_url = preg_replace('/https?:\/\//', '', $api_url);

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -165,7 +165,7 @@ class Blockonomics
                 // Exact match
                 return '';
             }
-            else if(strpos($server_callback_url, $api_url) === 0 || strpos($server_base_url, $base_url) === 0 ){
+            else if(strpos($server_base_url, $base_url) === 0 ){
                 // Partial Match - Only secret or protocol differ
                 $partial_match = $xpub;
             }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -131,19 +131,25 @@ class Blockonomics
     public function check_get_callbacks_response_body ($response, $crypto){
         $error_str = '';
         $response_body = json_decode(wp_remote_retrieve_body($response));
+        //If merchant doesn't have any xPubs on his Blockonomics account
         if (!isset($response_body) || count($response_body) == 0)
         {
             $error_str = __('You have not entered an xPub', 'blockonomics-bitcoin-payments');
         }
-        elseif (count($response_body) == 1)
+        //If merchant has at least one xPub on his Blockonomics account
+        elseif (count($response_body) >= 1)
         {
-            $response_callback = '';
-            $xpub = '';
+            //variables related to url-comparison
             $callback_secret = get_option('blockonomics_callback_secret');
             $api_url = WC()->api_request_url('WC_Gateway_Blockonomics');
             $callback_url = add_query_arg('secret', $callback_secret, $api_url);
             $base_url = get_bloginfo('wpurl');
             $base_url = preg_replace('/https?:\/\//', '', $base_url);
+            //variables that hold the results of the comparisons
+            $response_callback = '';
+            $xpub = '';
+            $matching_callback = false;
+            $available_xpub = '';
             if(isset($response_body[0])){
                 $response_callback = isset($response_body[0]->callback) ? $response_body[0]->callback : '';
                 $xpub = isset($response_body[0]->address) ? $response_body[0]->address : '';

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -139,7 +139,7 @@ class Blockonomics
         //if merchant has at least one xPub on his Blockonomics account
         elseif (count($response_body) >= 1)
         {
-            $result = examine_server_callback_urls($response_body, $crypto);
+            $result = $this->examine_server_callback_urls($response_body, $crypto);
             if(!$result['matching_callback'] && $result['available_xpub']){
                 $this->update_callback($wordpress_callback_url, $crypto, $available_xpub);
                 $matching_callback = true;

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -152,8 +152,6 @@ class Blockonomics
     {
         $base_url = preg_replace('/https?:\/\//', '', $api_url);
         $available_xpub = '';
-        $error_str = '';
-
         //Go through all xpubs on the server and examine their callback url
         foreach($response_body as $one_response){
             $server_callback_url = isset($one_response->callback) ? $one_response->callback : '';
@@ -166,7 +164,7 @@ class Blockonomics
                 return '';
             }
             // Partial Match - Only secret or protocol differ
-            else if(strpos($server_callback_url, $base_url)){
+            else if(strpos($server_callback_url, $api_url) === 0 || strpos($server_callback_url, $base_url)){
                 $this->update_callback($wordpress_callback_url, $crypto, $xpub);
                 return '';
             }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -155,6 +155,7 @@ class Blockonomics
         //Go through all xpubs on the server and examine their callback url
         foreach($response_body as $one_response){
             $server_callback_url = isset($one_response->callback) ? $one_response->callback : '';
+            $server_base_url = preg_replace('/https?:\/\//', '', $server_callback_url);
             $xpub = isset($one_response->address) ? $one_response->address : '';
             // No callback
             if(!$server_callback_url){
@@ -164,7 +165,7 @@ class Blockonomics
                 return '';
             }
             // Partial Match - Only secret or protocol differ
-            else if(strpos($server_callback_url, $api_url) === 0 || strpos($server_callback_url, $base_url)){
+            else if(strpos($server_callback_url, $api_url) === 0 || strpos($server_base_url, $base_url) === 0 ){
                 $this->update_callback($wordpress_callback_url, $crypto, $xpub);
                 return '';
             }


### PR DESCRIPTION
This is connected to issue #233 (Simplify callback checking in TestSetup). 

It follows the logic:

- First check if WP callback is exact match of an existing callback. Then do nothing
- Else replace callback with exact domain name match
- Else give error

This still need to be improved to work when merchant has set up multiple shops.