### PR TITLE
Fix for issue #241, sanitize the filter_by request

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -75,7 +75,7 @@ function blockonomics_woocommerce_init()
 		global $typenow;
 		if ( 'shop_order' === $typenow ) {
 			?>
-			<input size='26' value="<?php if(isset( $_GET['filter_by'] )) echo($_GET['filter_by']); ?>" type='name' placeholder='Filter by crypto address/txid' name='filter_by'>
+			<input size='26' value="<?php if(isset( $_GET['filter_by'] )) echo(sanitize_text_field($_GET['filter_by'])); ?>" type='name' placeholder='Filter by crypto address/txid' name='filter_by'>
 			<?php
 		}
 	}


### PR DESCRIPTION
Fix for the issue #241 
Correctly sanitizes the request data in the _filter_by_ input field using the WordPress [sanitize_text_field()](https://developer.wordpress.org/reference/functions/sanitize_text_field/) function.