### PR TITLE
Set header as Array instead of string

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 3.3.1  =
+* Minor bug fix
+
 = 3.3  =
 * Minor Security fixes
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** bitcoin, accept bitcoin, bitcoin woocommerce, bitcoin wordpress plugin, bitcoin payments 
 **Requires at least:** 3.0.1 
 **Tested up to:** 5.7
-**Stable tag:** 3.3
+**Stable tag:** 3.3.1
 **License:** MIT 
 **License URI:** http://opensource.org/licenses/MIT 
 

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WordPress Bitcoin Payments - Blockonomics
  * Plugin URI: https://github.com/blockonomics/woocommerce-plugin
  * Description: Accept Bitcoin Payments on your WooCommerce-powered website with Blockonomics
- * Version: 3.3
+ * Version: 3.3.1
  * Author: Blockonomics
  * Author URI: https://www.blockonomics.co
  * License: MIT

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -317,7 +317,7 @@ class Blockonomics
     private function set_headers($api_key)
     {
         if($api_key){
-            return 'Authorization: Bearer ' . $api_key;
+            return array('Authorization' => 'Bearer ' . $api_key);
         }else{
             return '';
         }


### PR DESCRIPTION
This PR is small and only contains two changes.

- Version changed from 3.3 => 3.3.1
-  `'Authorization: Bearer ' . $api_key;` is now `array('Authorization' => 'Bearer ' . $api_key);`

It works and follows WordPress' standards.