### PR TITLE
Fix duplicate orders

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -90,7 +90,7 @@ function CheckoutController($scope, $interval, Order, $timeout, Url) {
                     proccess_order_data();
                     $scope.checkout_panel  = true;
                 }else {
-                    if (data.error && (data.error.toLowerCase().indexOf("gap limit") !== -1 || data.error.toLowerCase().indexOf("temporary address") !== -1))
+                    if (data.error && (data.error.toLowerCase().indexOf("gap limit") !== -1 || data.error.toLowerCase().indexOf("temporary") !== -1))
                         $scope.customer_facing_error = data.error;
                     else
                         $scope.address_error[$scope.crypto.code] = true;

--- a/js/app.js
+++ b/js/app.js
@@ -88,6 +88,8 @@ function CheckoutController($scope, $interval, Order, $timeout, Url) {
                     // show the checkout page
                     proccess_order_data();
                     $scope.checkout_panel  = true;
+                }else if(data.error && data.error.toLowerCase().indexOf("temporary address") !== -1){
+                    $scope.address_error_duplicate = true;
                 }else if($scope.crypto.code === 'btc'){
                     if (data.error && data.error.toLowerCase().indexOf("gap limit") !== -1)
                       $scope.btc_gaplimit_error = data.error;

--- a/js/app.js
+++ b/js/app.js
@@ -76,6 +76,7 @@ function CheckoutController($scope, $interval, Order, $timeout, Url) {
     //Check if the blockonomics order is present
     function check_blockonomics_order() {
         $scope.spinner = true;
+        $scope.address_error = [];
         if (typeof $scope.order_id != 'undefined') {
             //Fetch the order using order_id
             Order.get({
@@ -88,15 +89,11 @@ function CheckoutController($scope, $interval, Order, $timeout, Url) {
                     // show the checkout page
                     proccess_order_data();
                     $scope.checkout_panel  = true;
-                }else if(data.error && data.error.toLowerCase().indexOf("temporary address") !== -1){
-                    $scope.address_error_duplicate = true;
-                }else if($scope.crypto.code === 'btc'){
-                    if (data.error && data.error.toLowerCase().indexOf("gap limit") !== -1)
-                      $scope.btc_gaplimit_error = data.error;
+                }else {
+                    if (data.error && (data.error.toLowerCase().indexOf("gap limit") !== -1 || data.error.toLowerCase().indexOf("temporary address") !== -1))
+                        $scope.error_message = data.error;
                     else
-                      $scope.address_error_btc = true;
-                }else if($scope.crypto.code === 'bch'){
-                    $scope.address_error_bch = true;
+                        $scope.address_error[$scope.crypto.code] = true;
                 }
             });
         }

--- a/js/app.js
+++ b/js/app.js
@@ -91,7 +91,7 @@ function CheckoutController($scope, $interval, Order, $timeout, Url) {
                     $scope.checkout_panel  = true;
                 }else {
                     if (data.error && (data.error.toLowerCase().indexOf("gap limit") !== -1 || data.error.toLowerCase().indexOf("temporary address") !== -1))
-                        $scope.error_message = data.error;
+                        $scope.customer_facing_error = data.error;
                     else
                         $scope.address_error[$scope.crypto.code] = true;
                 }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -554,11 +554,14 @@ class Blockonomics
     public function process_order($order_id, $crypto){
         $order = $this->get_order_by_id_and_crypto($order_id, $crypto);
         if ($order) {
+            // Update the existing order info
             $order = $this->calculate_order_params($order);
             $this->update_order($order);
         }else {
+            // Create and add the new order to the database
             $order = $this->create_new_order($order_id, $crypto);
             if (!$this->insert_order($order)) {
+                // insert_order fails if duplicate address found. Ensures no duplicate orders in the database
                 exit(json_encode(array("error"=>"Duplicate Address Error. This is Temporary error, Please try again")));
             }
             $this->record_address($order_id, $crypto, $order['address']);

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -562,7 +562,7 @@ class Blockonomics
             $order = $this->create_new_order($order_id, $crypto);
             if (!$this->insert_order($order)) {
                 // insert_order fails if duplicate address found. Ensures no duplicate orders in the database
-                exit(json_encode(array("error"=>"Duplicate Address Error. This is Temporary error, Please try again")));
+                exit(json_encode(array("error"=>__("Duplicate Address Error. This is Temporary error, Please try again", 'blockonomics-bitcoin-payments'))));
             }
             $this->record_address($order_id, $crypto, $order['address']);
         }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -559,7 +559,7 @@ class Blockonomics
         }else {
             $order = $this->create_new_order($order_id, $crypto);
             if (!$this->insert_order($order)) {
-                exit(json_encode(array("error"=>"Temporary address error, please try again")));
+                exit(json_encode(array("error"=>"Duplicate Address Error. This is Temporary error, Please try again")));
             }
             $this->record_address($order_id, $crypto, $order['address']);
         }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -562,7 +562,7 @@ class Blockonomics
             $order = $this->create_new_order($order_id, $crypto);
             if (!$this->insert_order($order)) {
                 // insert_order fails if duplicate address found. Ensures no duplicate orders in the database
-                exit(json_encode(array("error"=>__("Duplicate Address Error. This is Temporary error, Please try again", 'blockonomics-bitcoin-payments'))));
+                exit(json_encode(array("error"=>__("Duplicate Address Error. This is a Temporary error, please try again", 'blockonomics-bitcoin-payments'))));
             }
             $this->record_address($order_id, $crypto, $order['address']);
         }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -529,7 +529,7 @@ class Blockonomics
         return false;
     }
 
-    // Updates an order in blockonomics_orders table
+    // Inserts a new order in blockonomics_orders table
     public function insert_order($order){
         global $wpdb;
         $wpdb->hide_errors();

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -39,7 +39,7 @@ class Blockonomics
         $error_str = '';
         $callback_secret = get_option('blockonomics_callback_secret');
         $response = $this->new_address($callback_secret, $crypto, true);
-        if ($response->response_code!=200){	
+        if ($response->response_code!=200){ 
              $error_str = $response->response_message;
         }
         return $error_str;
@@ -487,7 +487,6 @@ class Blockonomics
             exit(json_encode(array("error"=>$responseObj->response_message)));
         }
         $address = $responseObj->address;
-
         $order = array(
                 'order_id'           => $order_id,
                 'status'             => -1,
@@ -495,8 +494,6 @@ class Blockonomics
                 'address'            => $address
         );
         $order = $this->calculate_order_params($order);
-
-        $this->record_address($order_id, $crypto, $address);
         return $order;
     }
 
@@ -533,6 +530,17 @@ class Blockonomics
     }
 
     // Updates an order in blockonomics_orders table
+    public function insert_order($order){
+        global $wpdb;
+        $wpdb->hide_errors();
+        $table_name = $wpdb->prefix . 'blockonomics_orders';
+        return $wpdb->insert( 
+            $table_name, 
+            $order 
+        );
+    }
+
+    // Updates an order in blockonomics_orders table
     public function update_order($order){
         global $wpdb;
         $table_name = $wpdb->prefix . 'blockonomics_orders';
@@ -547,11 +555,14 @@ class Blockonomics
         $order = $this->get_order_by_id_and_crypto($order_id, $crypto);
         if ($order) {
             $order = $this->calculate_order_params($order);
+            $this->update_order($order);
         }else {
             $order = $this->create_new_order($order_id, $crypto);
+            if (!$this->insert_order($order)) {
+                exit(json_encode(array("error"=>"Temporary address error, please try again")));
+            }
+            $this->record_address($order_id, $crypto, $order['address']);
         }
-        $this->update_order($order);
-
         return $order;
     }
 

--- a/templates/blockonomics_checkout.php
+++ b/templates/blockonomics_checkout.php
@@ -41,8 +41,8 @@ $blockonomics = new Blockonomics;
       </div>
       <!-- Duplicate Address Error -->
       <div id="address-error-duplicate" ng-show="address_error_duplicate" ng-cloak>
-        <h2><?=__('Temporary address error', 'blockonomics-bitcoin-payments')?></h2>
-        <p><?=__('Please refresh to try again', 'blockonomics-bitcoin-payments')?></p>
+        <h2><?=__('Duplicate Address Error', 'blockonomics-bitcoin-payments')?></h2>
+        <p><?=__('This is Temporary error, Please try again', 'blockonomics-bitcoin-payments')?></p>
       </div>
       <!-- Payment Expired -->
       <div class="bnomics-order-expired-wrapper" ng-show="order.status == -3" ng-cloak>

--- a/templates/blockonomics_checkout.php
+++ b/templates/blockonomics_checkout.php
@@ -35,9 +35,9 @@ $blockonomics = new Blockonomics;
         <p><?=__('Note to webmaster: Please follow the instructions <a href="https://help.blockonomics.co/en/support/solutions/articles/33000253348-bch-setup-on-woocommerce" target="_blank">here</a> to configure BCH payments.', 'blockonomics-bitcoin-payments')?></p>
       </div>
       <!-- Gap limit + Duplicate Address Error -->
-      <div id="address-error-message" ng-show="error_message" ng-cloak>
+      <div id="address-error-message" ng-show="customer_facing_error" ng-cloak>
         <h2><?=__('Could not generate new address', 'blockonomics-bitcoin-payments')?></h2>
-       <p>{{error_message}}</p>
+       <p>{{customer_facing_error}}</p>
       </div>
       <!-- Payment Expired -->
       <div class="bnomics-order-expired-wrapper" ng-show="order.status == -3" ng-cloak>

--- a/templates/blockonomics_checkout.php
+++ b/templates/blockonomics_checkout.php
@@ -39,6 +39,11 @@ $blockonomics = new Blockonomics;
         <h2><?=__('Could not generate new Bitcoin Cash address', 'blockonomics-bitcoin-payments')?></h2>
         <p><?=__('Note to webmaster: Please follow the instructions <a href="https://help.blockonomics.co/en/support/solutions/articles/33000253348-bch-setup-on-woocommerce" target="_blank">here</a> to configure BCH payments.', 'blockonomics-bitcoin-payments')?></p>
       </div>
+      <!-- Duplicate Address Error -->
+      <div id="address-error-duplicate" ng-show="address_error_duplicate" ng-cloak>
+        <h2><?=__('Temporary address error', 'blockonomics-bitcoin-payments')?></h2>
+        <p><?=__('Please refresh to try again', 'blockonomics-bitcoin-payments')?></p>
+      </div>
       <!-- Payment Expired -->
       <div class="bnomics-order-expired-wrapper" ng-show="order.status == -3" ng-cloak>
         <h3 class="warning bnomics-status-warning"><?=__('Payment Expired', 'blockonomics-bitcoin-payments')?></h3><br>

--- a/templates/blockonomics_checkout.php
+++ b/templates/blockonomics_checkout.php
@@ -24,25 +24,20 @@ $blockonomics = new Blockonomics;
         <h2><?=__('Display Error', 'blockonomics-bitcoin-payments')?></h2>
         <p><?=__('Unable to render correctly, Note to Administrator: Please enable lite mode in the Blockonomics plugin.', 'blockonomics-bitcoin-payments')?></p>
       </div>
-      <!-- Address Error -->
-      <div id="address-error-btc" ng-show="address_error_btc" ng-cloak>
+      <!-- BTC Address Error -->
+      <div id="address-error-btc" ng-show="address_error['btc']" ng-cloak>
         <h2><?=__('Could not generate new Bitcoin address', 'blockonomics-bitcoin-payments')?></h2>
         <p><?=__('Note to webmaster: Please login to your admin panel, navigate to Settings > Blockonomics > Currencies and click <i>Test Setup</i> to diagnose the issue.', 'blockonomics-bitcoin-payments')?></p>
       </div>
-      <!-- Gap limit Error -->
-      <div id="address-error-btc-gaplimit" ng-show="btc_gaplimit_error" ng-cloak>
-        <h2><?=__('Could not generate new Bitcoin address', 'blockonomics-bitcoin-payments')?></h2>
-       <p><?=__('Note to webmaster:', 'blockonomics-bitcoin-payments')?> {{btc_gaplimit_error}}.</p>
-      </div>
       <!-- BCH Address Error -->
-      <div id="address-error-bch" ng-show="address_error_bch" ng-cloak>
+      <div id="address-error-bch" ng-show="address_error['bch']" ng-cloak>
         <h2><?=__('Could not generate new Bitcoin Cash address', 'blockonomics-bitcoin-payments')?></h2>
         <p><?=__('Note to webmaster: Please follow the instructions <a href="https://help.blockonomics.co/en/support/solutions/articles/33000253348-bch-setup-on-woocommerce" target="_blank">here</a> to configure BCH payments.', 'blockonomics-bitcoin-payments')?></p>
       </div>
-      <!-- Duplicate Address Error -->
-      <div id="address-error-duplicate" ng-show="address_error_duplicate" ng-cloak>
-        <h2><?=__('Duplicate Address Error', 'blockonomics-bitcoin-payments')?></h2>
-        <p><?=__('This is Temporary error, Please try again', 'blockonomics-bitcoin-payments')?></p>
+      <!-- Gap limit + Duplicate Address Error -->
+      <div id="address-error-message" ng-show="error_message" ng-cloak>
+        <h2><?=__('Could not generate new address', 'blockonomics-bitcoin-payments')?></h2>
+       <p>{{error_message}}</p>
       </div>
       <!-- Payment Expired -->
       <div class="bnomics-order-expired-wrapper" ng-show="order.status == -3" ng-cloak>


### PR DESCRIPTION
Fixes issues with concurrent orders using the same bitcoin address.
- Saves the order to the blockonomics_orders table before updating the post metadata using record_address(). This ensures duplicates are checked before saving the address to the post
- Displays the _Temporary address error_ if SQL error on insert_order(), caused by the duplicate entry.

The fix can be tested using the following steps:
1. Create two new orders on WooCommerce. eg. Orders 1476 and 1477
2. Delete the two new orders from the blockonomics_orders table
3. Run the following curl command after replacing the two order_ids and your WordPress URL, in order to call get_order for both orders at the same time `seq 1476 1477 | xargs -I + -P2 curl 'http://localhost/wordpress/index.php/wc-api/WC_Gateway_Blockonomics?crypto=btc&get_order=+'`
One order receives the new address, the other exits with the _Temporary address error_