### PR TITLE
(add) Fix for CURCY Multi Currency Selector

### DIFF
--- a/css/order.css
+++ b/css/order.css
@@ -252,3 +252,10 @@
 @-webkit-keyframes spin {
   to { -webkit-transform: rotate(360deg); }
 }
+
+
+/** Woocommerce Multi Currency Support (CURCY) **/
+
+.woocommerce-multi-currency {
+  display: none!important;
+}


### PR DESCRIPTION
Hides the Currency Switcher in Blockonomics Order Pages when [Woocommerce Multi-Currency Plugin (CURCY)](https://villatheme.com/extensions/woo-multi-currency/) is enabled to prevent a change of currency in the middle of the checkout process.