### PR TITLE
Post release fix for v3.5.6

### DIFF
--- a/css/order.css
+++ b/css/order.css
@@ -204,6 +204,7 @@ svg {
 }
 
 .bnomics-select-container {
+/*padding-top is the space above crypto options on the select crypto page*/
   padding-top: 10vh;
   text-align:center;
   max-width:400px;

--- a/css/order.css
+++ b/css/order.css
@@ -204,7 +204,7 @@ svg {
 }
 
 .bnomics-select-container {
-  /* padding-top: 10vh; */
+  padding-top: 10vh;
   text-align:center;
   max-width:400px;
   margin:auto;


### PR DESCRIPTION
Closes https://github.com/blockonomics/woocommerce-plugin/issues/289 by uncommenting the `padding-top: 10vh;` i.e. reverting https://github.com/blockonomics/woocommerce-plugin/commit/1e49a3fad0c5fc14c38ad41707212c8ce347bf39