### PR TITLE
Pre 3.5.9 release refactor

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -523,11 +523,6 @@ function blockonomics_update_db_check() {
 function blockonomics_run_db_updates($installed_ver){
     global $wpdb;
     global $blockonomics_db_version;
-    if (version_compare($installed_ver, '1.1', '<')){
-        $table_name = $wpdb->prefix . 'blockonomics_orders';
-        maybe_drop_column($table_name, "time_remaining", "ALTER TABLE $table_name DROP COLUMN time_remaining");
-        maybe_drop_column($table_name, "timestamp", "ALTER TABLE $table_name DROP COLUMN timestamp");
-    }
     if (version_compare($installed_ver, '1.2', '<')){
         blockonomics_create_table();
     }

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -574,7 +574,8 @@ function blockonomics_uninstall_hook() {
     delete_option('blockonomics_network_confirmation');
 
     global $wpdb;
-    // if module is uninstalled, drop both tables blockonomics_orders & blockonomics_payments 
+    // drop blockonomics_orders & blockonomics_payments on uninstallation
+    // blockonomics_orders was the payments table before db version 1.2
     $wpdb->query($wpdb->prepare("DROP TABLE IF EXISTS ".$wpdb->prefix."blockonomics_orders , ".$wpdb->prefix."blockonomics_payments"));
     delete_option("blockonomics_db_version");
 }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -487,11 +487,8 @@ class Blockonomics
         if ( $order['payment_status'] == 0) {
             return $this->calculate_new_order_params($order);
         }
-        // Check if order has confirmed payment
         if ($order['payment_status'] == 2){
-            //check if order is underpaid
             if ($this->is_order_underpaid($order)){
-                // Create and add new row for underpaid order to the database
                 return $this->create_and_insert_new_order_on_underpayment($order);
             }
         }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -521,10 +521,7 @@ class Blockonomics
             // Some error in Address Generation from API, return the same array.
             return $order;
         }
-        if (!$this->insert_order($order)) {
-            // insert_order fails if duplicate address found. Ensures no duplicate orders in the database
-            return array("error"=>__("Duplicate Address Error. This is a Temporary error, please try again", 'blockonomics-bitcoin-payments'));
-        }
+        $this->insert_order($order);
         $this->record_address($order['order_id'], $order['crypto'], $order['address']);
         return $order;
     }
@@ -702,7 +699,7 @@ class Blockonomics
     }
 
 
-    // Inserts a new order in blockonomics_payments table
+    // Inserts a new row in blockonomics_payments table
     public function insert_order($order){
         global $wpdb;
         $wpdb->hide_errors();
@@ -737,10 +734,7 @@ class Blockonomics
                 // Some error in Address Generation from API, return the same array.
                 return $order;
             }
-            if (!$this->insert_order($order)) {
-                // insert_order fails if duplicate address found. Ensures no duplicate orders in the database
-                return array("error"=>__("Duplicate Address Error. This is a Temporary error, please try again", 'blockonomics-bitcoin-payments'));
-            }
+            $this->insert_order($order);
             $this->record_address($order_id, $crypto, $order['address']);
         }
         return $order;

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -879,8 +879,7 @@ class Blockonomics
         $coupon->set_usage_limit(1);// limit coupon to one time use
         $coupon->save();
         $wc_order->apply_coupon($coupon_code);
-
-        $coupon_note = "Partial payment received for " .get_woocommerce_currency()." ".sprintf('%0.2f', round($coupon->get_amount(), 2)). " and applied as a coupon.";
+        $coupon_note = "Partial payment of " .get_woocommerce_currency()." ".sprintf('%0.2f', round($coupon->get_amount(), 2)). " received via Blockonomics and applied as a coupon. Customer has been mailed invoice to pay remaining amount";
         $wc_order->add_order_note(__( $coupon_note, 'blockonomics-bitcoin-payments' ));
     }
 


### PR DESCRIPTION
This PR addresses @shivaenigma's review comments on [underpayment PR](https://github.com/blockonomics/woocommerce-plugin/pull/310). 

Changes done are as follows:

- Removed db check for version 1.1 in _blockonomics_run_db_updates_ function
- Removed trivial comments
- Removed error thrown if _insert_order_ fails
- Updated underpayment message shown on order details page

Note: I have opened an [issue](https://github.com/blockonomics/woocommerce-plugin/issues/316) regarding underpayment logic being called from _calculate_order_params_

---
Order details screenshots:
![2403-000975](https://user-images.githubusercontent.com/97018228/227510211-d3cd98fe-9bc7-4bd0-82e9-4f3b6e0f139e.jpg)
![2403-000974](https://user-images.githubusercontent.com/97018228/227510383-d8ad54e0-b0d9-4c09-8abe-4cbab31ff28e.jpg)

