### PR TITLE
Add partial payments checkbox in settings

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -330,12 +330,16 @@ function blockonomics_woocommerce_init()
                                         <option value="0" <?php selected(get_option('blockonomics_network_confirmation'), 0); ?>>0</option>
                                     </select></td>
                             </tr>
+                            <tr valign="top">
+                                <th scope="row"><?php echo __('Allow Partial Payments (Customer can pay order via multiple payments)', 'blockonomics-bitcoin-payments')?></th>
+                                <td><input onchange="add_asterisk('settings')" type="checkbox" name="blockonomics_partial_payments" value="1" <?php checked("1", get_option('blockonomics_partial_payments', $default_value = true)); ?> /></td>
+                            </tr>
                         </table>
                     </div>
                     <p class="submit">
                         <input type="submit" class="button-primary" value="<?php echo __("Save", 'blockonomics-bitcoin-payments')?>"/>
                         <input type="hidden" name="action" value="update" />
-                        <input type="hidden" name="page_options" value="blockonomics_api_key,blockonomics_timeperiod,blockonomics_margin,blockonomics_gen_callback,blockonomics_api_updated,blockonomics_underpayment_slack,blockonomics_lite,blockonomics_nojs,blockonomics_network_confirmation" />
+                        <input type="hidden" name="page_options" value="blockonomics_api_key,blockonomics_timeperiod,blockonomics_margin,blockonomics_gen_callback,blockonomics_api_updated,blockonomics_underpayment_slack,blockonomics_lite,blockonomics_nojs,blockonomics_network_confirmation,blockonomics_partial_payments" />
                     </p>
                 </form>
                 <form method="POST" name="generateSecretForm">
@@ -572,6 +576,7 @@ function blockonomics_uninstall_hook() {
     delete_option('blockonomics_lite');
     delete_option('blockonomics_nojs');
     delete_option('blockonomics_network_confirmation');
+    delete_option('blockonomics_partial_payments');
 
     global $wpdb;
     // drop blockonomics_orders & blockonomics_payments on uninstallation

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -826,7 +826,7 @@ class Blockonomics
                 $wc_order->save;
             }
             else {
-                $wc_order->update_status('failed', __('Paid amount less than expected.', 'blockonomics-bitcoin-payments'));
+                $wc_order->update_status('failed', __(get_woocommerce_currency()." ".sprintf('%0.2f', round($order['paid_fiat'], 2))." was paid via Blockonomics. Less than expected Order Amount.", 'blockonomics-bitcoin-payments'));
             }
         }
         else{

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -612,6 +612,8 @@ class Blockonomics
                 // Payment not confirmed i.e. payment in progress
                 // Redirect to order received page- dont alllow new payment until existing payments are confirmed
                 $this->redirect_finish_order($context['order_id']);
+            } else if (($order['payment_status'] == 2 && $this->is_order_underpaid($order)) && !$this->is_partial_payments_active() ) {
+                $error_context = $this->get_error_context('underpaid');
             } else {
                 // Display Checkout Page
                 $context['order_amount'] = $this->fix_displaying_small_values($order['expected_satoshi']);

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -401,7 +401,7 @@ class Blockonomics
     }
 
     public function is_partial_payments_active(){
-        return get_option('blockonomics_partial_payments', false);
+        return get_option('blockonomics_partial_payments', true);
     }
 
     public function is_error_template($template_name) {


### PR DESCRIPTION
Based on feedback after release of version 3.6, this PR gives merchants an option to disable/enable the partial payments flow using coupons. By default, partial payments are enabled.

---

**Screenshots**:
Advance settings
<img width="1080" alt="partial_payments_checkbox" src="https://user-images.githubusercontent.com/97018228/230467327-4e67a656-b1d5-4da9-ac0a-5a2c2d8da9f4.png">

**Behavior if partial payments are disabled**: similar as was in prior to v3.6 i.e. status is set to Failed and Order note is added

<img width="1080" alt="partial_payment_disabled" src="https://user-images.githubusercontent.com/97018228/230471221-7e92b806-bd50-4733-97c1-c4199a52858e.png">

Checkout when partial payments are disabled and order has been underpaid:
<img width="624" alt="underpaid_checkout" src="https://user-images.githubusercontent.com/97018228/230476220-0c26b9ec-0b27-4255-b643-09422c3ffd39.png">

Order note changed to show paid fiat amount in case of underpayment when partial payments are off:
<img width="185" alt="image" src="https://user-images.githubusercontent.com/97018228/231370796-7c0a1741-75fe-4299-ada7-ab09066d041e.png">


---

Use cases tested:
1. Fresh Install ✔
2. Upgrade from v3.6 ✔
4. No JS mode ✔
5. Lite Mode ✔
6. No JS + Lite Mode ✔