### PR TITLE
Add new features:Display links to the transaction id in the invoice

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -409,36 +409,37 @@ function blockonomics_woocommerce_init()
     function bnomics_display_tx_info($order, $email=false)
     {
         $blockonomics = new Blockonomics();
-        $active_cryptos = $blockonomics->getActiveCurrencies();
-        foreach ($active_cryptos as $crypto) {
-            $txid = get_post_meta($order->get_id(), 'blockonomics_payments_txids', true);
-            $address = get_post_meta($order->get_id(), 'blockonomics_payments_addresses', true);
+        $txid = get_post_meta($order->get_id(), 'blockonomics_payments_txids', true);
+        $address = get_post_meta($order->get_id(), 'blockonomics_payments_addresses', true);
 
-            if ($txid && $address) {
-                if ($crypto['code'] == 'btc') {
-                    $base_url = Blockonomics::BASE_URL;
-                }else{
-                    $base_url = Blockonomics::BCH_BASE_URL;
-                }
-                $txidArray = explode(",", $txid);
-                $addressdArray = explode(",", $address);
-                if (!empty($txidArray)) {
-                    echo '<b>'.__('Payment Details', 'blockonomics-bitcoin-payments').'</b><p><strong>'.__('Transaction', 'blockonomics-bitcoin-payments').':</strong>';
-                    for ($i = 0; $i < count($txidArray); $i++) {
-                       
-                       echo '<a href =\''. $base_url ."/api/tx?txid=$txidArray[$i]&addr=$addressdArray[$i]'>".substr($txidArray[$i], 0, 10). '</a>';
-                       if ($i < count($txidArray) - 1) {
-                          echo ', ';
-                       }
+        if ($txid && $address) {
+            $txidArray = explode(",", $txid);
+            $addressdArray = explode(",", $address);
+            if (!empty($txidArray)) {
+                echo '<b>'.__('Payment Details', 'blockonomics-bitcoin-payments').'</b><p><strong>'.__('Transaction', 'blockonomics-bitcoin-payments').':</strong>';
+                    
+                for ($i = 0; $i < count($txidArray); $i++) {
+                    
+                    $bchStartLetters = ['q', 'p'];
+                    $firstCharacter = substr($addressArray[$i], 0, 1);
+                    if (in_array($firstCharacter, $bchStartLetters)) {
+                        $base_url = Blockonomics::BCH_BASE_URL;
+                    }else{
+                        $base_url = Blockonomics::BASE_URL;
                     }
-                    echo '</p>';
+                    echo '<a href =\''. $base_url ."/api/tx?txid=$txidArray[$i]&addr=$addressdArray[$i]'>".substr($txidArray[$i], 0, 10). '</a>';
+                    if ($i < count($txidArray) - 1) {
+                        echo ', ';
+                    }
                 }
-        
-                if (!$email) {
-                   echo '<p>'.__('Your order will be processed on confirmation of above transaction by the bitcoin network.', 'blockonomics-bitcoin-payments').'</p>';
-                } 
+
+                echo '</p>';
             }
-        }      
+        
+            if (!$email) {
+               echo '<p>'.__('Your order will be processed on confirmation of above transaction by the bitcoin network.', 'blockonomics-bitcoin-payments').'</p>';
+            } 
+        }   
     }
     function nolo_custom_field_display_cust_order_meta($order)
     {

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -408,38 +408,42 @@ function blockonomics_woocommerce_init()
     }
     function bnomics_display_tx_info($order, $email=false)
     {
-        $blockonomics = new Blockonomics();
-        $txid = get_post_meta($order->get_id(), 'blockonomics_payments_txids', true);
-        $address = get_post_meta($order->get_id(), 'blockonomics_payments_addresses', true);
+        $txids = get_post_meta($order->get_id(), 'blockonomics_payments_txids', true);
+        $addresses = get_post_meta($order->get_id(), 'blockonomics_payments_addresses', true);
 
-        if ($txid && $address) {
-            $txidArray = explode(",", $txid);
-            $addressdArray = explode(",", $address);
-            if (!empty($txidArray)) {
-                echo '<b>'.__('Payment Details', 'blockonomics-bitcoin-payments').'</b><p><strong>'.__('Transaction', 'blockonomics-bitcoin-payments').':</strong>';
-                    
-                for ($i = 0; $i < count($txidArray); $i++) {
-                    
-                    $bchStartLetters = ['q', 'p'];
-                    $firstCharacter = substr($addressArray[$i], 0, 1);
-                    if (in_array($firstCharacter, $bchStartLetters)) {
-                        $base_url = Blockonomics::BCH_BASE_URL;
-                    }else{
-                        $base_url = Blockonomics::BASE_URL;
-                    }
-                    echo '<a href =\''. $base_url ."/api/tx?txid=$txidArray[$i]&addr=$addressdArray[$i]'>".substr($txidArray[$i], 0, 10). '</a>';
-                    if ($i < count($txidArray) - 1) {
-                        echo ', ';
-                    }
-                }
+        if (!$txids || !$addresses) {
+            return;
+        }
 
-                echo '</p>';
+        $txidArray = explode(",", $txids);
+        $addressArray = explode(",", $addresses);
+        $txidCount = count($txidArray);
+        $bchStartLetters = ['q', 'p'];
+
+        echo '<b>'.__('Payment Details', 'blockonomics-bitcoin-payments').'</b><p><strong>'.__('Transaction', 'blockonomics-bitcoin-payments').': </strong>';
+                    
+        for ($i = 0; $i < $txidCount; $i++) {
+            $firstCharacter = substr($addressArray[$i], 0, 1);
+
+            if (in_array($firstCharacter, $bchStartLetters)) {
+                $base_url = Blockonomics::BCH_BASE_URL;
+            } else {
+                $base_url = Blockonomics::BASE_URL;
             }
-        
-            if (!$email) {
-               echo '<p>'.__('Your order will be processed on confirmation of above transaction by the bitcoin network.', 'blockonomics-bitcoin-payments').'</p>';
-            } 
-        }   
+
+            echo '<a href =\''. $base_url ."/api/tx?txid=$txidArray[$i]&addr=$addressArray[$i]'>".substr($txidArray[$i], 0, 10). '</a>';
+
+            if ($i < $txidCount - 1) {
+                echo ', ';
+            }
+        }
+
+        echo '</p>';
+            
+        if (!$email) {
+            echo '<p>'.__('Your order will be processed on confirmation of above transaction by the bitcoin network.', 'blockonomics-bitcoin-payments').'</p>';
+        } 
+         
     }
     function nolo_custom_field_display_cust_order_meta($order)
     {

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -411,16 +411,8 @@ function blockonomics_woocommerce_init()
         global $wpdb;
         $order_id = $order->get_id();
         $table_name = $wpdb->prefix .'blockonomics_payments';
-        $query = $wpdb->prepare("SELECT * FROM ". $table_name." WHERE order_id = " . $order_id);
+        $query = $wpdb->prepare("SELECT * FROM ". $table_name." WHERE order_id = " . $order_id . " AND txid != ''");
         $transactions = $wpdb->get_results($query,ARRAY_A);
-
-        if (!is_array($transactions)) {
-            return;
-        }
-
-        $transactions = array_filter($transactions, function ($transaction) {
-            return isset($transaction['txid']) && !is_null($transaction['txid']);
-        });
 
         if (empty($transactions)) {
             return;

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -415,8 +415,8 @@ function blockonomics_woocommerce_init()
             return;
         }
 
-        $txidArray = explode(",", $txids);
-        $addressArray = explode(",", $addresses);
+        $txidArray = explode(", ", $txids);
+        $addressArray = explode(", ", $addresses);
         $txidCount = count($txidArray);
         $bchStartLetters = ['q', 'p'];
 

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -411,15 +411,29 @@ function blockonomics_woocommerce_init()
         $blockonomics = new Blockonomics();
         $active_cryptos = $blockonomics->getActiveCurrencies();
         foreach ($active_cryptos as $crypto) {
-            $txid = get_post_meta($order->get_id(), 'blockonomics_'.$crypto['code'].'_txid', true);
-            $address = get_post_meta($order->get_id(), $crypto['code'].'_address', true);
+            $txid = get_post_meta($order->get_id(), 'blockonomics_payments_txids', true);
+            $address = get_post_meta($order->get_id(), 'blockonomics_payments_addresses', true);
+
             if ($txid && $address) {
                 if ($crypto['code'] == 'btc') {
                     $base_url = Blockonomics::BASE_URL;
                 }else{
                     $base_url = Blockonomics::BCH_BASE_URL;
                 }
-                echo '<b>'.__('Payment Details', 'blockonomics-bitcoin-payments').'</b><p><strong>'.__('Transaction', 'blockonomics-bitcoin-payments').':</strong>  <a href =\''. $base_url ."/api/tx?txid=$txid&addr=$address'>".substr($txid, 0, 10). '</a></p>';
+                $txidArray = explode(",", $txid);
+                $addressdArray = explode(",", $address);
+                if (!empty($txidArray)) {
+                    echo '<b>'.__('Payment Details', 'blockonomics-bitcoin-payments').'</b><p><strong>'.__('Transaction', 'blockonomics-bitcoin-payments').':</strong>';
+                    for ($i = 0; $i < count($txidArray); $i++) {
+                       
+                       echo '<a href =\''. $base_url ."/api/tx?txid=$txidArray[$i]&addr=$addressdArray[$i]'>".substr($txidArray[$i], 0, 10). '</a>';
+                       if ($i < count($txidArray) - 1) {
+                          echo ', ';
+                       }
+                    }
+                    echo '</p>';
+                }
+        
                 if (!$email) {
                    echo '<p>'.__('Your order will be processed on confirmation of above transaction by the bitcoin network.', 'blockonomics-bitcoin-payments').'</p>';
                 } 

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -426,7 +426,7 @@ function blockonomics_woocommerce_init()
             return;
         }
 
-        echo '<b>'.__('Payment Details', 'blockonomics-bitcoin-payments').'</b><p><strong>'.__('Transactions', 'blockonomics-bitcoin-payments').': </strong><br />';
+        echo '<b>'.__('Payment Details', 'blockonomics-bitcoin-payments').'</b><br />';
                     
         foreach ($transactions as $transaction) {
             if($transaction['crypto'] == 'btc') {
@@ -434,7 +434,7 @@ function blockonomics_woocommerce_init()
             } else {
                 $base_url = Blockonomics::BCH_BASE_URL;
             }
-            echo '<a href="' . $base_url . '/api/tx?txid=' . $transaction['txid'] . '&addr=' . $transaction['address'] . '">' . $transaction['txid'] . '</a>';
+            echo '<a style="word-wrap: break-word;" href="' . $base_url . '/api/tx?txid=' . $transaction['txid'] . '&addr=' . $transaction['address'] . '">' . $transaction['txid'] . '</a>';
             echo '<br />';
         }
 


### PR DESCRIPTION
Adding a feature to display links to the transaction id in the invoice.

This PR fixes the issue https://github.com/blockonomics/woocommerce-plugin/issues/319

Single transaction id
![image](https://user-images.githubusercontent.com/91294460/231501273-f52e41c1-b56b-4347-aa28-04cd8a005c29.png)

Multiple transaction id
![image](https://user-images.githubusercontent.com/91294460/231501483-4a5791be-d151-42c1-b5f9-93b40f272638.png)

