### PR TITLE
 Filter Issue fixed for multiple txids and address

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -84,8 +84,21 @@ function blockonomics_woocommerce_init()
 	function filter_orders_by_address_or_txid( $vars ) {
 		global $typenow;
 		if ( 'shop_order' === $typenow && !empty( $_GET['filter_by'])) {
-			$vars['meta_value'] = wc_clean( sanitize_text_field(wp_unslash($_GET['filter_by'])) );
-		}
+            $santized_filter = wc_clean( sanitize_text_field(wp_unslash($_GET['filter_by'])) );
+            $vars['meta_query'] = array(
+                'relation' => 'OR',
+                array(
+                    'key'     => 'blockonomics_payments_addresses',
+                    'value'   => $santized_filter,
+                    'compare' => 'LIKE'
+                ),
+                array(
+                    'key'     => 'blockonomics_payments_txids',
+                    'value'   => $santized_filter,
+                    'compare' => 'LIKE'
+                ),
+            );
+        }
 		return $vars;
 	}
     /**


### PR DESCRIPTION
This fixes issue #314 

After changes : We can have multiple addresses & transaction ids but when this happens, they are now searchable from Filter on the Order History page (image attached).
![image](https://user-images.githubusercontent.com/91294460/232728974-3dfc33b9-9c01-4b37-8c0e-807f949997f6.png)

Order 20 (multiple txid and address)
![image](https://user-images.githubusercontent.com/91294460/232729864-7fb4a3e6-a84f-4ea5-b9d4-f7cafc94d4d3.png)


