### PR TITLE
Resolves the bug  caused due to shortcode executing multiple times 

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -84,18 +84,21 @@ function blockonomics_woocommerce_init()
     }
 
     function add_payment_page_shortcode() {
-        $show_order = isset($_GET["show_order"]) ? sanitize_text_field(wp_unslash($_GET['show_order'])) : "";
-        $crypto = isset($_GET["crypto"]) ? sanitize_key($_GET['crypto']) : "";
-        $select_crypto = isset($_GET["select_crypto"]) ? sanitize_text_field(wp_unslash($_GET['select_crypto'])) : "";
-        $blockonomics = new Blockonomics;
+        $currentFilter = current_filter();
+        if ($currentFilter == 'the_content') {
+            $show_order = isset($_GET["show_order"]) ? sanitize_text_field(wp_unslash($_GET['show_order'])) : "";
+            $crypto = isset($_GET["crypto"]) ? sanitize_key($_GET['crypto']) : "";
+            $select_crypto = isset($_GET["select_crypto"]) ? sanitize_text_field(wp_unslash($_GET['select_crypto'])) : "";
+            $blockonomics = new Blockonomics;
 
-        if ($crypto === "empty") {
-            return $blockonomics->load_blockonomics_template('no_crypto_selected');
-        } else if ($show_order && $crypto) {
-            $order_id = $blockonomics->decrypt_hash($show_order);
-            return $blockonomics->load_checkout_template($order_id, $crypto);
-        } else if ($select_crypto) {
-            return $blockonomics->load_blockonomics_template('crypto_options');
+            if ($crypto === "empty") {
+                return $blockonomics->load_blockonomics_template('no_crypto_selected');
+            } else if ($show_order && $crypto) {
+                $order_id = $blockonomics->decrypt_hash($show_order);
+                return $blockonomics->load_checkout_template($order_id, $crypto);
+            } else if ($select_crypto) {
+                return $blockonomics->load_blockonomics_template('crypto_options');
+            }
         }
     }
     /**

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -84,21 +84,26 @@ function blockonomics_woocommerce_init()
     }
 
     function add_payment_page_shortcode() {
+        // This is to make sure we only run the shortcode when executed to render the page.
+        // Because the shortcode can be run multiple times by other plugin like All in One SEO.
+        // Where it tries to build SEO content from the shortcode and this could lead to checkout page not loading correctly.
         $currentFilter = current_filter();
-        if ($currentFilter == 'the_content') {
-            $show_order = isset($_GET["show_order"]) ? sanitize_text_field(wp_unslash($_GET['show_order'])) : "";
-            $crypto = isset($_GET["crypto"]) ? sanitize_key($_GET['crypto']) : "";
-            $select_crypto = isset($_GET["select_crypto"]) ? sanitize_text_field(wp_unslash($_GET['select_crypto'])) : "";
-            $blockonomics = new Blockonomics;
+        if ($currentFilter != 'the_content') {
+            return;
+        }
+        
+        $show_order = isset($_GET["show_order"]) ? sanitize_text_field(wp_unslash($_GET['show_order'])) : "";
+        $crypto = isset($_GET["crypto"]) ? sanitize_key($_GET['crypto']) : "";
+        $select_crypto = isset($_GET["select_crypto"]) ? sanitize_text_field(wp_unslash($_GET['select_crypto'])) : "";
+        $blockonomics = new Blockonomics;
 
-            if ($crypto === "empty") {
-                return $blockonomics->load_blockonomics_template('no_crypto_selected');
-            } else if ($show_order && $crypto) {
-                $order_id = $blockonomics->decrypt_hash($show_order);
-                return $blockonomics->load_checkout_template($order_id, $crypto);
-            } else if ($select_crypto) {
-                return $blockonomics->load_blockonomics_template('crypto_options');
-            }
+        if ($crypto === "empty") {
+            return $blockonomics->load_blockonomics_template('no_crypto_selected');
+        } else if ($show_order && $crypto) {
+            $order_id = $blockonomics->decrypt_hash($show_order);
+            return $blockonomics->load_checkout_template($order_id, $crypto);
+        } else if ($select_crypto) {
+            return $blockonomics->load_blockonomics_template('crypto_options');
         }
     }
     /**

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -461,7 +461,7 @@ class Blockonomics
         extract($context);
         // Load the checkout template
         ob_start(); // Start buffering
-        include plugin_dir_path(__FILE__)."../templates/" .$template;
+        include_once plugin_dir_path(__FILE__)."../templates/" .$template;
         return ob_get_clean(); // Return the buffered content
     }
 
@@ -607,7 +607,9 @@ class Blockonomics
                 $context['payment_uri'] = $this->get_crypto_payment_uri($context['crypto'], $order['address'], $context['order_amount']);
                 $context['crypto_rate_str'] = $this->get_crypto_rate_from_params($order['expected_fiat'], $order['expected_satoshi']);
                 //Using svg library qrcode.php to generate QR Code in NoJS mode
-                $context['qrcode_svg_element'] = $this->generate_qrcode_svg_element($context['payment_uri']);
+                if($this->is_nojs_active()){
+                    $context['qrcode_svg_element'] = $this->generate_qrcode_svg_element($context['payment_uri']);
+                }
 
                 $context['total'] = $order['expected_fiat'];
                 $paid_fiat = $this->get_order_paid_fiat($order['order_id']);
@@ -896,7 +898,7 @@ class Blockonomics
     }
 
     public function generate_qrcode_svg_element($data) {
-        include plugin_dir_path(__FILE__) . 'qrcode.php';
+        include_once plugin_dir_path(__FILE__) . 'qrcode.php';
         $codeText = sanitize_text_field($data);
         return QRcode::svg($codeText);
     } 


### PR DESCRIPTION
Recently, we released WordPress 3.6.5 and encountered a bug where the shortcode is parsed or executed multiple times. This can occur for various reasons, such as the SEO plugin parsing the shortcode multiple times.
![image](https://github.com/blockonomics/woocommerce-plugin/assets/91294460/ed27f952-d838-408b-a003-a9f026fd3409)

This fix ensures that the shortcode runs only once by making certain all files are included just a single time. The QR code for 'nojs' is executed only when 'no-js' is activated

