### PR TITLE
Fixing additional script bug on block theme

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -550,7 +550,7 @@ function blockonomics_woocommerce_init()
         wp_register_script( 'reconnecting-websocket', plugins_url('js/vendors/reconnecting-websocket.min.js#deferload', __FILE__), array(), get_plugin_data( __FILE__ )['Version'] );
         wp_register_script( 'qrious', plugins_url('js/vendors/qrious.min.js#deferload', __FILE__), array(), get_plugin_data( __FILE__ )['Version'] );
         wp_register_script( 'copytoclipboard', plugins_url('js/vendors/copytoclipboard.js#deferload', __FILE__), array(), get_plugin_data( __FILE__ )['Version'] );
-        wp_register_script( 'bnomics-checkout', plugins_url('js/checkout.js#deferload', __FILE__), array('reconnecting-websocket', 'qrious','copytoclipboard'), get_plugin_data( __FILE__ )['Version'] );  
+        wp_register_script( 'bnomics-checkout', plugins_url('js/checkout.js#deferload', __FILE__), array('reconnecting-websocket', 'qrious','copytoclipboard'), get_plugin_data( __FILE__ )['Version'], array('in_footer' => true  ) );  
     }
 
 

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -436,7 +436,9 @@ class Blockonomics
     public function add_blockonomics_checkout_style($template_name, $additional_script=NULL){
         wp_enqueue_style( 'bnomics-style' );
         if ($template_name === 'checkout') {
-            wp_add_inline_script('bnomics-checkout', $additional_script, 'before');
+            add_action('wp_footer', function() use ($additional_script) {
+                printf('<script type="text/javascript">%s</script>', $additional_script);
+            });
             wp_enqueue_script( 'bnomics-checkout' );
         }
     }


### PR DESCRIPTION
## What happened?
- With our new change for payment page as shortcode, additional scripts which incldues `blockonomics_data` is not added for block based themes like Twentytwentythree.

## Impact?
All block based themes cannot load the checkout page as it shows a Display Error and has a JS error in the browser console.

## Fix?
To fix, instead of using `wp_add_inline_script` to add the script we need to use `wp_footer` action by adding the additional script at the bottom of the page.