### PR TITLE
Fixed JS script url and added defer attribute

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -63,7 +63,6 @@ function blockonomics_woocommerce_init()
     add_filter('woocommerce_get_checkout_payment_url','update_payment_url_on_underpayments',10,2);
     add_filter('request', 'filter_orders_by_address_or_txid' ); 
     add_filter('woocommerce_payment_gateways', 'woocommerce_add_blockonomics_gateway');
-    add_filter('clean_url', 'bnomics_async_scripts', 11, 1 );
     add_shortcode('blockonomics_payment', 'add_payment_page_shortcode');
     add_action('wp_enqueue_scripts', 'bnomics_register_stylesheets');
     add_action('wp_enqueue_scripts', 'bnomics_register_scripts');
@@ -547,22 +546,10 @@ function blockonomics_woocommerce_init()
     }
 
     function bnomics_register_scripts(){
-        wp_register_script( 'reconnecting-websocket', plugins_url('js/vendors/reconnecting-websocket.min.js#deferload', __FILE__), array(), get_plugin_data( __FILE__ )['Version'] );
-        wp_register_script( 'qrious', plugins_url('js/vendors/qrious.min.js#deferload', __FILE__), array(), get_plugin_data( __FILE__ )['Version'] );
-        wp_register_script( 'copytoclipboard', plugins_url('js/vendors/copytoclipboard.js#deferload', __FILE__), array(), get_plugin_data( __FILE__ )['Version'] );
-        wp_register_script( 'bnomics-checkout', plugins_url('js/checkout.js#deferload', __FILE__), array('reconnecting-websocket', 'qrious','copytoclipboard'), get_plugin_data( __FILE__ )['Version'], array('in_footer' => true  ) );  
-    }
-
-
-    // Async load
-    function bnomics_async_scripts($url)
-    {
-        if ( strpos( $url, '#deferload') === false )
-            return $url;
-        else if ( is_admin() )
-            return str_replace( '#deferload', '', $url );
-        else
-        return str_replace( '#deferload', '', $url )."' defer='defer"; 
+        wp_register_script( 'reconnecting-websocket', plugins_url('js/vendors/reconnecting-websocket.min.js', __FILE__), array(), get_plugin_data( __FILE__ )['Version'], array( 'strategy' => 'defer' ) );
+        wp_register_script( 'qrious', plugins_url('js/vendors/qrious.min.js', __FILE__), array(), get_plugin_data( __FILE__ )['Version'], array( 'strategy' => 'defer' ) );
+        wp_register_script( 'copytoclipboard', plugins_url('js/vendors/copytoclipboard.js', __FILE__), array(), get_plugin_data( __FILE__ )['Version'], array( 'strategy' => 'defer' ) );
+        wp_register_script( 'bnomics-checkout', plugins_url('js/checkout.js', __FILE__), array('reconnecting-websocket', 'qrious','copytoclipboard'), get_plugin_data( __FILE__ )['Version'], array('in_footer' => true, 'strategy' => 'defer'  ) );  
     }
 }
 


### PR DESCRIPTION
Previously we used `clear_url` filter hook to added the defer attribute to the script tag. Which recently has been deprecated and is generating a invalid url for scripts. It looks something like this

```html
<script src="js/checkout.js?ver=3.6.7' defer='defer'"></script>
```

Now changed this by passing a stratergy `defer` to the `wp_register_script()`  and this creates the url correctly as below

```html
<script src="js/checkout.js?ver=3.6.9" defer="defer" data-wp-strategy="defer"></script>
```