### PR TITLE
Remove unwanted import to fix Warning: Constant DB_NAME already defined

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -38,7 +38,6 @@ if (!defined('ABSPATH')) {
 
 require_once ABSPATH . 'wp-admin/includes/plugin.php';
 require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
-require_once ABSPATH . 'wp-admin/install-helper.php';
 
 use Automattic\WooCommerce\Utilities\OrderUtil;
 


### PR DESCRIPTION
This PR removes unwanted `require` to fix the Warnings which happens when running any WP–CLI command.

Fixes - https://wordpress.org/support/topic/warning-constant-db_name-already-defined-in-wp-config-php

