### PR TITLE
Fixing DynamicProperties error by declaring $api_key

### DIFF
--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -38,7 +38,8 @@ class Blockonomics
         return $rounded_total_paid_fiats;
 
     }
-    
+
+    private $api_key;
     
     public function __construct()
     {


### PR DESCRIPTION
This fixes the deprecation error where from PHP 8.2 we're starting to see this error