### PR TITLE
Fix headers already sent error in version 3.7.4

### DIFF
--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -38,8 +38,9 @@ class Blockonomics
         return $rounded_total_paid_fiats;
 
     }
-    
-    
+
+    private $api_key;
+
     public function __construct()
     {
         $this->api_key = $this->get_api_key();
@@ -134,7 +135,7 @@ class Blockonomics
         $response = $this->get($url, $this->api_key);
         return $response;
     }
-    
+
     public function check_get_callbacks_response_code($response){
         $error_str = '';
         //TODO: Check This: WE should actually check code for timeout

--- a/php/form_fields.php
+++ b/php/form_fields.php
@@ -1,5 +1,6 @@
-
 <?php
+
+defined( 'ABSPATH' ) || exit;
 
 class FormFields {
     public static function init_form_fields($callback_url = '') {


### PR DESCRIPTION
The debug log shared by merchant [here](https://wordpress.org/support/topic/latest-update-prevented-admin-login-account-creation/) shows a php warning about "Headers already sent"

`PHP Warning: Cannot modify header information - headers already sent by (output started at /homepages/44/MDSP/htdocs/wordpress/wp-content/plugins/blockonomics-bitcoin-payments/php/form_fields.php:1) in /homepages/44/MDSP/htdocs/wordpress/wp-includes/http.php on line 505
`

This is caused by [empty line before php tag](https://github.com/blockonomics/woocommerce-plugin/blob/4e9fa04a622afadc7767286ad2807598338dcd4f/php/form_fields.php#L1) declaration in `php/form_fields.php` file. This is causing php functions that need to send HTTP headers (like setcookie(), session_start(), or header()) to fail because content has already been sent to the browser.

This file also had missing ABSPATH check. Without this check, if someone knows the file's URL, they could potentially access and execute the file directly, making this a potential security risk. I've added this statement in this PR to fix this.
