### PR TITLE
Move BCH to advanced settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup PHP, with Composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.1'  # Ensuring PHP 8.1 is used
+        php-version: '8.1'
         extensions: mbstring, xml, curl, pdo_mysql
         coverage: pcov
         tools: composer:v2
@@ -34,15 +34,16 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
 
-    - name: Start MySQL
-      run: sudo /etc/init.d/mysql start
+    - name: Verify MySQL connection
+      run: |
+        sudo apt-get install -y mysql-client
+        mysql --host 127.0.0.1 -uroot -proot -e "SHOW DATABASES"
 
     - name: Prepare WordPress Database
       run: |
-        mysql -e 'CREATE DATABASE wordpress_tests;' -uroot -proot
-        mysql -e "CREATE USER 'wp'@'localhost' IDENTIFIED BY 'wp';" -uroot -proot
-        mysql -e "GRANT ALL PRIVILEGES ON wordpress_tests.* TO 'wp'@'localhost';" -uroot -proot
-        mysql -e 'FLUSH PRIVILEGES;' -uroot -proot
+        mysql --host 127.0.0.1 -uroot -proot -e "CREATE USER IF NOT EXISTS 'wp'@'localhost' IDENTIFIED BY 'wp';"
+        mysql --host 127.0.0.1 -uroot -proot -e "GRANT ALL PRIVILEGES ON wordpress_tests.* TO 'wp'@'localhost';"
+        mysql --host 127.0.0.1 -uroot -proot -e "FLUSH PRIVILEGES;"
 
     - name: Run PHPUnit tests
       run: vendor/bin/phpunit tests/

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,10 @@
 {
     "name": "blockonomics/test",
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.5",
-        "10up/wp_mock": "^0.5.0"
+        "phpunit/phpunit": "^8.5",
+        "10up/wp_mock": "^0.4.2",
+        "mockery/mockery": "^1.3",
+        "doctrine/instantiator": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1da18739cb620c15fb4612c8c7e3b9c",
+    "content-hash": "f640e70057f47cd81cd6fe4af057b959",
     "packages": [],
     "packages-dev": [
         {
             "name": "10up/wp_mock",
-            "version": "0.5.0",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/10up/wp_mock.git",
-                "reference": "5cd57c63b1a946301ce0d7aaaa37cdc25805c163"
+                "reference": "9019226eb50df275aa86bb15bfc98a619601ee49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/10up/wp_mock/zipball/5cd57c63b1a946301ce0d7aaaa37cdc25805c163",
-                "reference": "5cd57c63b1a946301ce0d7aaaa37cdc25805c163",
+                "url": "https://api.github.com/repos/10up/wp_mock/zipball/9019226eb50df275aa86bb15bfc98a619601ee49",
+                "reference": "9019226eb50df275aa86bb15bfc98a619601ee49",
                 "shasum": ""
             },
             "require": {
                 "antecedent/patchwork": "^2.1",
-                "mockery/mockery": "^1.5",
-                "php": ">=7.3 < 9.0",
-                "phpunit/phpunit": "^9.5.24"
+                "mockery/mockery": "^1.0",
+                "php": ">=7.1",
+                "phpunit/phpunit": ">=7.0"
             },
             "require-dev": {
-                "behat/behat": "^v3.11.0",
-                "php-coveralls/php-coveralls": "^v2.5.3",
-                "sebastian/comparator": "^4.0.8",
-                "sempro/phpunit-pretty-print": "^1.4"
+                "behat/behat": "^3.0",
+                "php-coveralls/php-coveralls": "^2.1",
+                "sebastian/comparator": ">=1.2.3"
             },
             "type": "library",
             "autoload": {
@@ -47,28 +46,24 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A mocking library to take the pain out of unit testing for WordPress",
-            "support": {
-                "issues": "https://github.com/10up/wp_mock/issues",
-                "source": "https://github.com/10up/wp_mock/tree/0.5.0"
-            },
-            "time": "2022-11-01T03:01:40+00:00"
+            "time": "2019-03-16T03:44:39+00:00"
         },
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.28",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "6b30aff81ebadf0f2feb9268d3e08385cebcc08d"
+                "reference": "b07d4fb37c3c723c8755122160c089e077d5de65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/6b30aff81ebadf0f2feb9268d3e08385cebcc08d",
-                "reference": "6b30aff81ebadf0f2feb9268d3e08385cebcc08d",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b07d4fb37c3c723c8755122160c089e077d5de65",
+                "reference": "b07d4fb37c3c723c8755122160c089e077d5de65",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
                 "phpunit/phpunit": ">=4"
@@ -95,38 +90,34 @@
                 "runkit",
                 "testing"
             ],
-            "support": {
-                "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.28"
-            },
-            "time": "2024-02-06T09:26:11+00:00"
+            "time": "2024-09-27T16:59:55+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -151,10 +142,6 @@
                 "constructor",
                 "instantiate"
             ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -169,7 +156,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -216,10 +203,6 @@
             "keywords": [
                 "test"
             ],
-            "support": {
-                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
-            },
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
@@ -296,27 +279,20 @@
                 "test double",
                 "testing"
             ],
-            "support": {
-                "docs": "https://docs.mockery.io/",
-                "issues": "https://github.com/mockery/mockery/issues",
-                "rss": "https://github.com/mockery/mockery/releases.atom",
-                "security": "https://github.com/mockery/mockery/security/advisories",
-                "source": "https://github.com/mockery/mockery"
-            },
             "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -324,11 +300,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -352,75 +329,13 @@
                 "object",
                 "object graph"
             ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
-            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v5.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-json": "*",
-                "ext-tokenizer": "*",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
-            },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -477,10 +392,6 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "support": {
-                "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
-            },
             "funding": [
                 {
                     "url": "https://github.com/theseer",
@@ -534,52 +445,44 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "support": {
-                "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.2.1"
-            },
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "7.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "40a4ed114a4aea5afd6df8d0f0c9cd3033097f66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/40a4ed114a4aea5afd6df8d0f0c9cd3033097f66",
+                "reference": "40a4ed114a4aea5afd6df8d0f0c9cd3033097f66",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.2.2"
             },
             "suggest": {
-                "ext-pcov": "PHP extension that provides line coverage",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-xdebug": "^2.7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -605,43 +508,38 @@
                 "testing",
                 "xunit"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-03-02T06:09:37+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "69deeb8664f611f156a924154985fbd4911eb36b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/69deeb8664f611f156a924154985fbd4911eb36b",
+                "reference": "69deeb8664f611f156a924154985fbd4911eb36b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -666,107 +564,32 @@
                 "filesystem",
                 "iterator"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
-        },
-        {
-            "name": "phpunit/php-invoker",
-            "version": "3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-pcntl": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Invoke callables with a timeout",
-            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-            "keywords": [
-                "process"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2024-03-01T13:39:50+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "php": ">=5.3.3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -788,42 +611,32 @@
             "keywords": [
                 "template"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "a691211e94ff39a34811abd521c31bd5b305b0bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a691211e94ff39a34811abd521c31bd5b305b0bb",
+                "reference": "a691211e94ff39a34811abd521c31bd5b305b0bb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -847,64 +660,114 @@
             "keywords": [
                 "timer"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2024-03-01T13:42:41+00:00"
         },
         {
-            "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "name": "phpunit/php-token-stream",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/a853a0e183b9db7eed023d7933a858fa1c8d25a3",
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "ext-tokenizer": "*",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-08-04T08:28:15+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "8.5.40",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "48ed828b72c35b38cdddcd9059339734cb06b3a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/48ed828b72c35b38cdddcd9059339734cb06b3a7",
+                "reference": "48ed828b72c35b38cdddcd9059339734cb06b3a7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.2",
+                "phpunit/php-code-coverage": "^7.0.17",
+                "phpunit/php-file-iterator": "^2.0.6",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.4",
+                "sebastian/comparator": "^3.0.5",
+                "sebastian/diff": "^3.0.6",
+                "sebastian/environment": "^4.2.5",
+                "sebastian/exporter": "^3.1.6",
+                "sebastian/global-state": "^3.0.5",
+                "sebastian/object-enumerator": "^3.0.5",
+                "sebastian/resource-operations": "^2.0.3",
+                "sebastian/type": "^1.1.5",
+                "sebastian/version": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage",
+                "phpunit/php-invoker": "To allow enforcing time limits"
             },
             "bin": [
                 "phpunit"
@@ -912,13 +775,10 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-master": "8.5-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "src/Framework/Assert/Functions.php"
-                ],
                 "classmap": [
                     "src/"
                 ]
@@ -941,11 +801,6 @@
                 "testing",
                 "xunit"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
-            },
             "funding": [
                 {
                     "url": "https://phpunit.de/sponsors.html",
@@ -960,144 +815,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
-        },
-        {
-            "name": "sebastian/cli-parser",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for parsing CLI options",
-            "homepage": "https://github.com/sebastianbergmann/cli-parser",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-02T06:27:43+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2024-09-19T10:47:04+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54",
+                "reference": "92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -1117,44 +860,40 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2024-03-01T13:45:45+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1191,100 +930,39 @@
                 "compare",
                 "equality"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
-        },
-        {
-            "name": "sebastian/complexity",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for calculating the complexity of PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/complexity",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2022-09-14T12:31:48+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "98ff311ca519c3aa73ccd3de053bdb377171d7b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/98ff311ca519c3aa73ccd3de053bdb377171d7b6",
+                "reference": "98ff311ca519c3aa73ccd3de053bdb377171d7b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1314,37 +992,33 @@
                 "unidiff",
                 "unified diff"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-03-02T06:16:36+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "4.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "56932f6049a0482853056ffd617c91ffcc754205"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/56932f6049a0482853056ffd617c91ffcc754205",
+                "reference": "56932f6049a0482853056ffd617c91ffcc754205",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^7.5"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -1352,7 +1026,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1377,44 +1051,40 @@
                 "environment",
                 "hhvm"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-03-01T13:49:59+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "1939bc8fd1d39adcfa88c5b35335910869214c56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/1939bc8fd1d39adcfa88c5b35335910869214c56",
+                "reference": "1939bc8fd1d39adcfa88c5b35335910869214c56",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=7.2",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1449,45 +1119,41 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2024-03-02T06:21:38+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "91c7c47047a971f02de57ed6f040087ef110c5d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/91c7c47047a971f02de57ed6f040087ef110c5d9",
+                "reference": "91c7c47047a971f02de57ed6f040087ef110c5d9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^8.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1495,7 +1161,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1518,101 +1184,40 @@
             "keywords": [
                 "global state"
             ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
-        },
-        {
-            "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for counting the lines of code in PHP source code",
-            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2024-03-02T06:13:16+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "ac5b293dba925751b808e02923399fb44ff0d541"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/ac5b293dba925751b808e02923399fb44ff0d541",
+                "reference": "ac5b293dba925751b808e02923399fb44ff0d541",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1632,42 +1237,38 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2024-03-01T13:54:02+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "1d439c229e61f244ff1f211e5c99737f90c67def"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/1d439c229e61f244ff1f211e5c99737f90c67def",
+                "reference": "1d439c229e61f244ff1f211e5c99737f90c67def",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -1687,42 +1288,38 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2024-03-01T13:56:04+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "9bfd3c6f1f08c026f542032dfb42813544f7d64c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/9bfd3c6f1f08c026f542032dfb42813544f7d64c",
+                "reference": "9bfd3c6f1f08c026f542032dfb42813544f7d64c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1749,43 +1346,36 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "https://github.com/sebastianbergmann/recursion-context",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
-            },
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2024-03-01T14:07:30+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.4",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+                "reference": "72a7f7674d053d548003b16ff5a106e7e0e06eee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/72a7f7674d053d548003b16ff5a106e7e0e06eee",
+                "reference": "72a7f7674d053d548003b16ff5a106e7e0e06eee",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1805,41 +1395,38 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2024-03-01T13:59:09+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "18f071c3a29892b037d35e6b20ddf3ea39b42874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/18f071c3a29892b037d35e6b20ddf3ea39b42874",
+                "reference": "18f071c3a29892b037d35e6b20ddf3ea39b42874",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -1860,39 +1447,35 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
-            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2024-03-01T14:04:07+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=5.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1913,17 +1496,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1963,10 +1536,6 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "support": {
-                "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
-            },
             "funding": [
                 {
                     "url": "https://github.com/theseer",
@@ -1983,5 +1552,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -127,13 +127,11 @@ class Blockonomics
 
     public function get_callbacks($crypto)
     {
-        if ($crypto === 'btc'){
-            $url = Blockonomics::GET_CALLBACKS_URL;
-        }else{
-            $url = Blockonomics::BCH_GET_CALLBACKS_URL;
+        if ($crypto !== 'btc') {
+            return false;
         }
-        $response = $this->get($url, $this->api_key);
-        return $response;
+        $url = self::GET_CALLBACKS_URL;
+        return $this->get($url, $this->api_key);
     }
 
     public function check_get_callbacks_response_code($response){

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -112,11 +112,7 @@ class Blockonomics
 
     public function update_callback($callback_url, $crypto, $xpub)
     {
-        if ($crypto === 'btc'){
-            $url = Blockonomics::SET_CALLBACK_URL;
-        }else{
-            $url = Blockonomics::BCH_SET_CALLBACK_URL;
-        }
+        $url = Blockonomics::SET_CALLBACK_URL;
         $body = json_encode(array('callback' => $callback_url, 'xpub' => $xpub));
         $response = $this->post($url, $this->api_key, $body);
         $responseObj = json_decode(wp_remote_retrieve_body($response));

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -12,10 +12,7 @@ class Blockonomics
     const GET_CALLBACKS_URL = 'https://www.blockonomics.co/api/address?&no_balance=true&only_xpub=true&get_callback=true';
 
     const BCH_BASE_URL = 'https://bch.blockonomics.co';
-    const BCH_NEW_ADDRESS_URL = 'https://bch.blockonomics.co/api/new_address';
     const BCH_PRICE_URL = 'https://bch.blockonomics.co/api/price';
-    const BCH_SET_CALLBACK_URL = 'https://bch.blockonomics.co/api/update_callback';
-    const BCH_GET_CALLBACKS_URL = 'https://bch.blockonomics.co/api/address?&no_balance=true&only_xpub=true&get_callback=true';
 
 
     function get_order_paid_fiat($order_id) {

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -229,11 +229,6 @@ class Blockonomics
                     'code' => 'btc',
                     'name' => 'Bitcoin',
                     'uri' => 'bitcoin'
-              ),
-              'bch' => array(
-                    'code' => 'bch',
-                    'name' => 'Bitcoin Cash',
-                    'uri' => 'bitcoincash'
               )
           );
     }  
@@ -241,15 +236,7 @@ class Blockonomics
      * Get list of active crypto currencies
      */
     public function getActiveCurrencies() {
-        $active_currencies = array();
-        $blockonomics_currencies = $this->getSupportedCurrencies();
-        foreach ($blockonomics_currencies as $code => $currency) {
-            $enabled = get_option('blockonomics_'.$code);
-            if($enabled || ($code === 'btc' && $enabled === false )){
-                $active_currencies[$code] = $currency;
-            }
-        }
-        return $active_currencies;
+        return $this->getSupportedCurrencies();
     }
 
     private function get($url, $api_key = '')

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -74,11 +74,7 @@ class Blockonomics
         {
             $get_params = "?match_callback=$secret";
         }
-        if($crypto === 'btc'){
-            $url = Blockonomics::NEW_ADDRESS_URL.$get_params;
-        }else{
-            $url = Blockonomics::BCH_NEW_ADDRESS_URL.$get_params;            
-        }
+        $url = Blockonomics::NEW_ADDRESS_URL.$get_params;
         $response = $this->post($url, $this->api_key, '', 8);
         if (!isset($responseObj)) $responseObj = new stdClass();
         $responseObj->{'response_code'} = wp_remote_retrieve_response_code($response);

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -13,6 +13,7 @@ class Blockonomics
 
     const BCH_BASE_URL = 'https://bch.blockonomics.co';
     const BCH_PRICE_URL = 'https://bch.blockonomics.co/api/price';
+    const BCH_NEW_ADDRESS_URL = 'https://bch.blockonomics.co/api/new_address';
 
 
     function get_order_paid_fiat($order_id) {
@@ -71,7 +72,7 @@ class Blockonomics
         {
             $get_params = "?match_callback=$secret";
         }
-        $url = Blockonomics::NEW_ADDRESS_URL.$get_params;
+        $url = ($crypto === 'bch') ? self::BCH_NEW_ADDRESS_URL : self::NEW_ADDRESS_URL;
         $response = $this->post($url, $this->api_key, '', 8);
         if (!isset($responseObj)) $responseObj = new stdClass();
         $responseObj->{'response_code'} = wp_remote_retrieve_response_code($response);
@@ -219,6 +220,11 @@ class Blockonomics
                     'code' => 'btc',
                     'name' => 'Bitcoin',
                     'uri' => 'bitcoin'
+                ),
+                'bch' => array(
+                    'code' => 'bch',
+                    'name' => 'Bitcoin Cash',
+                    'uri' => 'bitcoincash'
               )
           );
     }  
@@ -226,7 +232,14 @@ class Blockonomics
      * Get list of active crypto currencies
      */
     public function getActiveCurrencies() {
-        return $this->getSupportedCurrencies();
+        $active_currencies = array();
+        $blockonomics_currencies = $this->getSupportedCurrencies();
+        foreach ($blockonomics_currencies as $code => $currency) {
+            if ($code === 'btc' || ($code === 'bch' && get_option('woocommerce_blockonomics_settings')['enable_bch'] === 'yes')) {
+                $active_currencies[$code] = $currency;
+            }
+        }
+        return $active_currencies;
     }
 
     private function get($url, $api_key = '')

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -307,6 +307,10 @@ class Blockonomics
             return __('Set your Blockonomics API Key', 'blockonomics-bitcoin-payments');
         }
 
+        if ($crypto !== 'btc') {
+            return __('Test Setup only supports BTC', 'blockonomics-bitcoin-payments');
+        }
+
         $response = $this->get_callbacks($crypto);
         $error_str = $this->check_callback_urls_or_set_one($crypto, $response);
         if (!$error_str)
@@ -314,11 +318,7 @@ class Blockonomics
             //Everything OK ! Test address generation
             $error_str = $this->test_new_address_gen($crypto, $response);
         }
-        if($error_str) {
-            return $error_str;
-        }
-        // No errors
-        return false;
+        return $error_str ? $error_str : false;
     }
 
     // Returns WC page endpoint of order adding the given extra parameters

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -208,6 +208,9 @@ class Blockonomics
 
     public function check_callback_urls_or_set_one($crypto, $response) 
     {
+        if ($crypto !== 'btc') {
+            return __('Test Setup only supports BTC', 'blockonomics-bitcoin-payments');
+        }
         //chek the current callback and detect any potential errors
         $error_str = $this->check_get_callbacks_response_code($response, $crypto);
         if(!$error_str){

--- a/php/WC_Gateway_Blockonomics.php
+++ b/php/WC_Gateway_Blockonomics.php
@@ -266,13 +266,14 @@ class WC_Gateway_Blockonomics extends WC_Payment_Gateway
                                 $blockonomics = new Blockonomics;
                                 $cryptos = $blockonomics->getSupportedCurrencies();
                                 foreach ($cryptos as $currencyCode => $crypto) {
-        
-                                    echo '<p class="notice notice-success ' . $currencyCode . '-success-notice" style="display:none;width:400px;">'.strtoupper($currencyCode).' - Success</p>';
-                                    echo '<p class="notice notice-error ' . $currencyCode . '-error-notice" style="width:400px;display:none;">';
-                                    echo strtoupper($currencyCode).' - ';
-                                    echo '<span class="errorText"></span><br />';
-                                    echo 'Please consult <a href="http://help.blockonomics.co/support/solutions/articles/33000215104-unable-to-generate-new-address" target="_blank">this troubleshooting article</a>.';
-                                    echo '</p>';
+                                    if ($currencyCode !== 'bch') {
+                                        echo '<p class="notice notice-success ' . $currencyCode . '-success-notice" style="display:none;width:400px;">'.strtoupper($currencyCode).' - Success</p>';
+                                        echo '<p class="notice notice-error ' . $currencyCode . '-error-notice" style="width:400px;display:none;">';
+                                        echo strtoupper($currencyCode).' - ';
+                                        echo '<span class="errorText"></span><br />';
+                                        echo 'Please consult <a href="http://help.blockonomics.co/support/solutions/articles/33000215104-unable-to-generate-new-address" target="_blank">this troubleshooting article</a>.';
+                                        echo '</p>';
+                                    }
                                 }
                             ?>
                         </div>

--- a/php/WC_Gateway_Blockonomics.php
+++ b/php/WC_Gateway_Blockonomics.php
@@ -355,12 +355,15 @@ class WC_Gateway_Blockonomics extends WC_Payment_Gateway
         }
 
         $blockonomics = new Blockonomics;
-        $activeCurrencies = $blockonomics->getSupportedCurrencies();
+        $supportedCurrencies = $blockonomics->getSupportedCurrencies();
 
-        foreach ($activeCurrencies as $code => $currency) {
-            $optionName = 'blockonomics_' . strtolower($code);
-            $isEnabled = $this->get_option($code . '_enabled') == 'yes' ? 1 : 0;
-            update_option($optionName, $isEnabled);
+        foreach ($supportedCurrencies as $code => $currency) {
+            if ($code === 'btc') {
+                update_option('blockonomics_' . $code, 1);
+            } elseif ($code === 'bch') {
+                $isEnabled = $this->get_option('enable_bch') === 'yes' ? 1 : 0;
+                update_option('blockonomics_' . $code, $isEnabled);
+            }
         }
         update_option('blockonomics_margin', (int)$this->get_option('extra_margin'));
         update_option('blockonomics_underpayment_slack', (int)$this->get_option('underpayment_slack'));

--- a/php/form_fields.php
+++ b/php/form_fields.php
@@ -65,6 +65,13 @@ class FormFields {
             'default' =>  get_option('blockonomics_underpayment_slack', 0),
             'placeholder' => __('Underpayment Slack %', 'blockonomics-bitcoin-payments')
         );
+        $form_fields['enable_bch'] = array(
+            'title' => __('', 'blockonomics-bitcoin-payments'),
+            'type' => 'checkbox',
+            'subtitle' => __('Enable Bitcoin Cash (BCH)', 'blockonomics-bitcoin-payments'),
+            'label' => __('Allow customers to pay with Bitcoin Cash', 'blockonomics-bitcoin-payments'),
+            'default' => 'no',
+        );
         $form_fields['no_javascript'] = array(
             'title' => __('', 'blockonomics-bitcoin-payments'),
             'type' => 'checkbox',

--- a/php/form_fields.php
+++ b/php/form_fields.php
@@ -46,20 +46,6 @@ class FormFields {
             )
         );
 
-        $firstItem = true;
-        foreach ($cryptos as $currencyCode => $crypto) {
-            $title = $firstItem ? 'Currencies<p class="block-title-desc">Setting and testing currencies accepted </p>' : '';
-            $default = $currencyCode === 'btc' ? 1 : 0;
-            $form_fields[$currencyCode . '_enabled'] = array(
-                'title'   => $title,
-                'type'    => 'checkbox',
-                'subtitle'   => $crypto["name"] . ' (' . strtoupper($currencyCode) . ')',
-                'label'   => __('Enable accepting '.$crypto["name"]),
-                'default' => get_option('blockonomics_' . $currencyCode, $default) == 1 ? 'yes' : 'no',
-                'add_divider' => $firstItem
-            );
-            $firstItem = false;
-        }
 
         $form_fields['extra_margin'] = array(
             'title' => __('Advanced<p class="block-title-desc">Setting for advanced control</p>', 'blockonomics-bitcoin-payments'),

--- a/tests/BlockonomicsTest.php
+++ b/tests/BlockonomicsTest.php
@@ -5,7 +5,6 @@ use Mockery as m;
 
 class TestableBlockonomics extends Blockonomics {
     public function __construct($api_key = 'temporary_api_key') {
-        // Directly use the provided API key or a default one, bypassing get_option
         $this->api_key = $api_key;
     }
 }
@@ -15,49 +14,46 @@ class BlockonomicsTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
         wp::setUp();
-        // $this->blockonomics = new TestableBlockonomics();
         $this->blockonomics = m::mock(TestableBlockonomics::class, ['ZJ4PNtTnKqWxeMCQ6smlMBvj3i3KAtt2hwLSGuk9Lyk'])->makePartial();
-        // Mock WordPress get_option function
+
+        // Mock WordPress functions
         wp::userFunction('get_option', [
             'return' => function($option_name) {
                 switch ($option_name) {
-                    case 'blockonomics_bch':
-                        return true; // Assume BCH is enabled
                     case 'blockonomics_btc':
-                        return true; // Assume BTC is disabled
+                        return true;
                     case 'blockonomics_api_key':
-                        return 'ZJ4PNtTnKqWxeMCQ6smlMBvj3i3KAtt2hwLSGuk9Lyk'; // Dummy API key
+                        return 'ZJ4PNtTnKqWxeMCQ6smlMBvj3i3KAtt2hwLSGuk9Lyk';
                     case 'blockonomics_callback_secret':
-                        return '2c5a71c1367e23a6b04a20544d0d4a4601c34881'; // Dummy callback secret
+                        return '2c5a71c1367e23a6b04a20544d0d4a4601c34881';
                     default:
                         return null;
                 }
             }
         ]);
-        // Mock wp_remote_retrieve_response_code and wp_remote_retrieve_body
+
         wp::userFunction('wp_remote_retrieve_response_code', [
             'return' => function($response) {
                 return isset($response['response']['code']) ? $response['response']['code'] : null;
             }
         ]);
+
         wp::userFunction('wp_remote_retrieve_body', [
             'return' => function($response) {
                 return isset($response['body']) ? $response['body'] : [];
             }
         ]);
-        // Mock WC() function
+
         wp::userFunction('WC', [
             'return' => function() {
                 return new class{
                     public function api_request_url($endpoint) {
                         return "https://localhost:8888/wordpress/wc-api/WC_Gateway_Blockonomics/";
-                        //TODO: look for variations in http cases
                     }
-                    };
+                };
             }
         ]);
 
-        // Mock add_query_arg function i.e. appends query arguments to a URL
         wp::userFunction('add_query_arg', [
             'return' => function($args, $url) {
                 if (!is_array($args)) {
@@ -66,6 +62,7 @@ class BlockonomicsTest extends TestCase {
                 return $url . '?' . http_build_query($args);
             }
         ]);
+
         wp::userFunction('is_wp_error', [
             'return' => function($thing) {
                 return ($thing instanceof \WP_Error);
@@ -73,10 +70,10 @@ class BlockonomicsTest extends TestCase {
         ]);
     }
 
+    // Existing tests that are still relevant
     public function testCalculateTotalPaidFiatWithNoTransactions() {
-        // Mocking wc_get_price_decimals to return 2 decimals
         wp::userFunction('wc_get_price_decimals', [
-            'times'  => 1, // Ensure this function is called exactly once
+            'times'  => 1,
             'return' => 2,
         ]);
 
@@ -86,7 +83,6 @@ class BlockonomicsTest extends TestCase {
     }
 
     public function testCalculateTotalPaidFiatWithVariousTransactions() {
-        // Mocking wc_get_price_decimals to return 2 decimals
         wp::userFunction('wc_get_price_decimals', [
             'times'  => 1,
             'return' => 2,
@@ -117,14 +113,6 @@ class BlockonomicsTest extends TestCase {
         $this->assertEquals($expectedUri, $this->blockonomics->get_crypto_payment_uri($crypto, $address, $order_amount));
     }
 
-    public function testGetCryptoPaymentUriForBCH() {
-        $crypto = ['uri' => 'bitcoincash'];
-        $address = "qr3fmxznghk8h0af7mpj0ay590ev5js72chef5md3w";
-        $order_amount = 0.1;
-        $expectedUri = "bitcoincash:qr3fmxznghk8h0af7mpj0ay590ev5js72chef5md3w?amount=0.1";
-        $this->assertEquals($expectedUri, $this->blockonomics->get_crypto_payment_uri($crypto, $address, $order_amount));
-    }
-
     public function testGetSupportedCurrencies() {
         $expectedCurrencies = [
             'btc' => [
@@ -142,96 +130,59 @@ class BlockonomicsTest extends TestCase {
         $this->assertEquals($expectedCurrencies, $actualCurrencies, "The getSupportedCurrencies method did not return the expected array of cryptocurrencies.");
     }
 
-    public function testSetHeadersWithEmptyApiKey() {
-        $reflection = new \ReflectionClass($this->blockonomics);
-        $method = $reflection->getMethod('set_headers');
-        $method->setAccessible(true); // Makes private method accessible
-    
-        $result = $method->invokeArgs($this->blockonomics, ['']);
-        $this->assertEquals('', $result);
-    }
-    
-    public function testSetHeadersWithNonEmptyApiKey() {
-        $reflection = new \ReflectionClass($this->blockonomics);
-        $method = $reflection->getMethod('set_headers');
-        $method->setAccessible(true); // Makes private method accessible
-    
-        $apiKey = "your_api_key";
-        $expectedHeader = 'Authorization: Bearer ' . $apiKey;
-        $result = $method->invokeArgs($this->blockonomics, [$apiKey]);
-        $this->assertEquals($expectedHeader, $result);
-    }
-    
-    private function mockActiveCurrencies(array $cryptos) {
-        $activeCurrencies = [];
-        foreach ($cryptos as $crypto) {
-            switch ($crypto) {
-                case 'btc':
-                    $activeCurrencies['btc'] = ['code' => 'btc', 'name' => 'Bitcoin', 'uri' => 'bitcoin'];
-                    break;
-                case 'bch':
-                    $activeCurrencies['bch'] = ['code' => 'bch', 'name' => 'Bitcoin Cash', 'uri' => 'bitcoincash'];
-                    break;
-            }
-        }
+    // Modified test setup tests
+    public function testBTCWithIncorrectAPIKeySetup() {
         $this->blockonomics->shouldReceive('getActiveCurrencies')
             ->once()
-            ->andReturn($activeCurrencies);
+            ->andReturn(['btc' => ['code' => 'btc', 'name' => 'Bitcoin', 'uri' => 'bitcoin']]);
+
+        $this->blockonomics->shouldReceive('get_callbacks')
+            ->with('btc')
+            ->andReturn([
+                'response' => [
+                    'code' => 401,
+                    'message' => 'Unauthorized'
+                ]
+            ]);
+
+        $result = $this->blockonomics->testSetup();
+        $this->assertEquals(['btc' => 'API Key is incorrect'], $result);
     }
 
-    // Define different mock responses for callback API
-    private function getMockResponse($type) {
-        switch ($type) {
-            case 'incorrect_api_key':
-                return [
-                    'response' => [
-                        'code' => 401,
-                        'message' => 'Unauthorized'
-                    ]
-                ];
-            case 'no_stores_added':
-                return [
-                    'response' => [
-                        'code' => 200,
-                        'message' => 'OK'
-                    ],
-                    'body' => json_encode([])  // no stores added
-                ];
-            case 'one_store_different_callback':
-                return [
-                    'response' => [
-                        'code' => 200,
-                        'message' => 'OK'
-                    ],
-                    'body' => json_encode([['address' => 'zpub6o4sVoUnjZ8qWRtWUFHL9TWKfStSo2rquV6LsHJWNDbrEP5L2CAG849xpXJXzsm4iNTbKGS6Q4gxK6mYQqfd1JCP3KKYco2DBxTrjpywWxt', 'tag' => 't_shirt_store_wordpress', 'callback' => 'http://localhost:8888/wordpress/wc-api/WC_Gateway_Blockonomics/?secret=30d8ea3494a820e37ffb46c801a6cce96cc2023e']])
-                ];
-            case 'one_store_no_callback':
-                return [
-                    'response' => [
-                        'code' => 200,
-                        'message' => 'OK'
-                    ],
-                    'body' => json_encode([['address' => 'zpub6o4sVoUnjZ8qWRtWUFHL9TWKfStSo2rquV6LsHJWNDbrEP5L2CAG849xpXJXzsm4iNTbKGS6Q4gxK6mYQqfd1JCP3KKYco2DBxTrjpywWxt', 'tag' => 't_shirt_store_wordpress', 'callback' => '']])
-                ];
-            default:
-                return [
-                    'response' => [
-                        'code' => 400,
-                        'body' => 'Bad Request'
-                    ]
-                ];
-        }
+    public function testBTCWithNoStore() {
+        $this->blockonomics->shouldReceive('getActiveCurrencies')
+            ->once()
+            ->andReturn(['btc' => ['code' => 'btc', 'name' => 'Bitcoin', 'uri' => 'bitcoin']]);
+
+        $this->blockonomics->shouldReceive('get_callbacks')
+            ->with('btc')
+            ->andReturn([
+                'response' => [
+                    'code' => 200,
+                    'message' => 'OK'
+                ],
+                'body' => json_encode([])
+            ]);
+
+        $result = $this->blockonomics->testSetup();
+        $this->assertEquals(['btc' => 'Please add a new store on blockonomics website'], $result);
     }
 
-    private function mockGetCallbacks(array $cryptos, $responseType){
-        $mockedResponse = $this->getMockResponse($responseType);
-        foreach ($cryptos as $crypto) {
-            $this->blockonomics->shouldReceive('get_callbacks')
-                ->with($crypto)
-                ->andReturn($mockedResponse);
-        }
-    }
-    private function mockUpdateCallbackResponse() {
+    public function testBTCWithOneStoreNoCallback() {
+        $this->blockonomics->shouldReceive('getActiveCurrencies')
+            ->once()
+            ->andReturn(['btc' => ['code' => 'btc', 'name' => 'Bitcoin', 'uri' => 'bitcoin']]);
+
+        $this->blockonomics->shouldReceive('get_callbacks')
+            ->with('btc')
+            ->andReturn([
+                'response' => [
+                    'code' => 200,
+                    'message' => 'OK'
+                ],
+                'body' => json_encode([['address' => 'zpub6o4sVoUnjZ8qWRtWUFHL9TWKfStSo2rquV6LsHJWNDbrEP5L2CAG849xpXJXzsm4iNTbKGS6Q4gxK6mYQqfd1JCP3KKYco2DBxTrjpywWxt', 'tag' => 't_shirt_store_wordpress', 'callback' => '']])
+            ]);
+
         wp::userFunction('wp_remote_post', [
             'return' => [
                 'response' => [
@@ -241,172 +192,16 @@ class BlockonomicsTest extends TestCase {
                 'body' => ''
             ]
         ]);
-    }
 
-    // Testing Test Setup functionality
-    // Case 1: Incorrect API Key is set and only BCH is enabled
-    public function testBCHWithIncorrectAPIKeySetup() {
-        // Mock getActiveCurrencies to return only BCH
-        $this->mockActiveCurrencies(['bch']);
-        // Use getMockResponse to get the mock response for incorrect API key
-        $mockedResponse = $this->getMockResponse('incorrect_api_key');
-        // Mock the response for get_callbacks to simulate incorrect API key
-        $this->mockGetCallbacks(['bch'], 'incorrect_api_key');
-        // Execute testSetup and capture the results
         $result = $this->blockonomics->testSetup();
-        // Assert that the error "API Key is incorrect" is returned for BCH
-        $this->assertEquals(['bch' => 'API Key is incorrect'], $result);
-    }
-
-    // Case 2: Incorrect API Key is set and only BTC is enabled
-    public function testBTCWithIncorrectAPIKeySetup() {
-        // Mock getActiveCurrencies to return only BTC
-        $this->mockActiveCurrencies(['btc']);
-        $mockedResponse = $this->getMockResponse('incorrect_api_key');        
-        $this->mockGetCallbacks(['btc'], 'incorrect_api_key');
-        $result = $this->blockonomics->testSetup();
-        $this->assertEquals(['btc' => 'API Key is incorrect'], $result);
-    }
-
-    // Case 3: BTC & BCH are enabled and API key set is incorrect
-    public function testBTCandBCHWithIncorrectAPIKeySetup() {
-        // Mock getActiveCurrencies to return both BTC and BCH
-        $this->mockActiveCurrencies(['btc', 'bch']);
-        $mockedResponse = $this->getMockResponse('incorrect_api_key');        
-        $this->mockGetCallbacks(['btc','bch'], 'incorrect_api_key');
-        $result = $this->blockonomics->testSetup();
-        // Assert that the error "API Key is incorrect" is returned for both BTC and BCH
-        $this->assertEquals(['btc' => 'API Key is incorrect', 'bch' => 'API Key is incorrect'], $result);
-    }
-
-    //Case 4: only BCH is enabled, API Key is correct but no xpub is added
-    public function testBCHWithNoStore() {
-        // Mock getActiveCurrencies to return only BCH
-        $this->mockActiveCurrencies(['bch']);
-        // Use getMockResponse to simulate no stores added with a correct API key
-        $mockedResponse = $this->getMockResponse('no_stores_added');
-        $this->mockGetCallbacks(['bch'], 'no_stores_added');
-        // Execute testSetup and capture the results
-        $result = $this->blockonomics->testSetup();
-        // Assert that the error message for no store added is returned for BCH
-        $this->assertEquals(['bch' => 'Please add a new store on blockonomics website'], $result);
-    }
-
-    //Case 5: only BTC is enabled, API Key is correct but no xpub is added
-    public function testBTCWithNoStore() {
-        // Mock getActiveCurrencies to return only BTC
-        $this->mockActiveCurrencies(['btc']);
-        // Use getMockResponse to simulate no stores added with a correct API key
-        $mockedResponse = $this->getMockResponse('no_stores_added');
-        $this->mockGetCallbacks(['btc'], 'no_stores_added');
-        // Execute testSetup and capture the results
-        $result = $this->blockonomics->testSetup();
-        // Assert that the error message for no store added is returned for BTC
-        $this->assertEquals(['btc' => 'Please add a new store on blockonomics website'], $result);
-    }
-
-    // Case 6: both BTC, BCH enabled , API Key is correct but no xpub added for any of BTC/BCH
-    public function testBTCandBCHWithNoStore() {
-        // Mock active currencies for both BTC and BCH
-        $this->mockActiveCurrencies(['btc', 'bch']);
-        // Use getMockResponse to simulate no stores added with a correct API key
-        $mockedResponse = $this->getMockResponse('no_stores_added');
-        $this->mockGetCallbacks(['btc', 'bch'], 'no_stores_added');
-        $result = $this->blockonomics->testSetup();
-        // Assert that the error message for no store added is returned for both BTC and BCH
-        $this->assertEquals(['btc' => 'Please add a new store on blockonomics website', 'bch' => 'Please add a new store on blockonomics website'], $result);
-    }
-
-    // API key is correct, 1 xpub is added and callback url is not set
-    public function testBTCWithOneStoreNoCallback() {
-        // Mock active currencies to return only BTC
-        $this->mockActiveCurrencies(['btc']);
-
-        // Simulate the response where one store is added without any callback URL
-        $this->blockonomics->shouldReceive('get_callbacks')
-            ->with('btc')
-            ->andReturn($this->getMockResponse('one_store_no_callback'));
-
-        // Mock the update callback response
-        $this->mockUpdateCallbackResponse();
-
-        // Execute testSetup and capture the results
-        $result = $this->blockonomics->testSetup();
-
-        // Assert that no errors are returned
         $this->assertFalse($result['btc']);
     }
 
-    public function testBCHWithOneStoreNoCallback() {
-        // Mock active currencies to return only BCH
-        $this->mockActiveCurrencies(['bch']);
-
-        // Simulate the response where one store is added without any callback URL
-        $this->blockonomics->shouldReceive('get_callbacks')
-            ->with('bch')
-            ->andReturn($this->getMockResponse('one_store_no_callback'));
-
-        // Mock the update callback response
-        $this->mockUpdateCallbackResponse();
-
-        // Execute testSetup and capture the results
-        $result = $this->blockonomics->testSetup();
-
-        // Assert that no errors are returned
-        $this->assertFalse($result['bch']);
-    }
-
-    public function testBTCandBCHWithOneStoreNoCallback() {
-        // Mock active currencies to return only BTC
-        $this->mockActiveCurrencies(['btc','bch']);
-
-        // Simulate the response where one store is added without any callback URL
-        $this->blockonomics->shouldReceive('get_callbacks')
-            ->with('btc')
-            ->andReturn($this->getMockResponse('one_store_no_callback'));
-
-        $this->blockonomics->shouldReceive('get_callbacks')
-            ->with('bch')
-            ->andReturn($this->getMockResponse('one_store_no_callback'));
-
-        // Mock the update callback response
-        $this->mockUpdateCallbackResponse();
-
-        // Execute testSetup and capture the results
-        $result = $this->blockonomics->testSetup();
-
-        // Assert that no errors are returned
-        $this->assertFalse($result['btc']);
-        $this->assertFalse($result['bch']);
-    }
-
-    // Tests focused on Callbacks functionality
-
+    // Existing callback tests
     public function testUpdateCallbackForBTC() {
         $callbackUrl = 'https://example.com/callback';
         $crypto = 'btc';
         $xpub = 'xpub12345';
-        $expectedUrl = Blockonomics::SET_CALLBACK_URL;
-        $expectedBody = json_encode(['callback' => $callbackUrl, 'xpub' => $xpub]);
-        wp::userFunction('wp_remote_post', [
-            'return' => [
-                'response' => [
-                    'code' => 200,
-                    'message' => 'OK'
-                ],
-                'body' => json_encode(['status' => 'success'])
-            ]
-        ]);
-        $result = $this->blockonomics->update_callback($callbackUrl, $crypto, $xpub);
-        $this->assertEquals(200, $result->response_code);
-    }
-
-    public function testUpdateCallbackForBCH() {
-        $callbackUrl = 'https://example.com/callback';
-        $crypto = 'bch';
-        $xpub = 'xpub12345';
-        $expectedUrl = Blockonomics::BCH_SET_CALLBACK_URL;
-        $expectedBody = json_encode(['callback' => $callbackUrl, 'xpub' => $xpub]);
         wp::userFunction('wp_remote_post', [
             'return' => [
                 'response' => [
@@ -424,8 +219,6 @@ class BlockonomicsTest extends TestCase {
         $callbackUrl = 'https://example.com/callback';
         $crypto = 'btc';
         $xpub = 'xpub12345';
-        $expectedUrl = Blockonomics::SET_CALLBACK_URL;
-        $expectedBody = json_encode(['callback' => $callbackUrl, 'xpub' => $xpub]);
         wp::userFunction('wp_remote_post', [
             'return' => [
                 'response' => [
@@ -448,42 +241,6 @@ class BlockonomicsTest extends TestCase {
             (object) ['callback' => 'https://otherurl.com', 'address' => 'xpub2']
         ];
 
-        $crypto = 'btc';
-
-        // Mock WordPress get_option function
-        wp::userFunction('get_option', [
-            'args' => ['blockonomics_callback_secret'],
-            'return' => $callbackSecret,
-        ]);
-
-        // Mock WordPress WC function
-        wp::userFunction('WC', [
-            'return' => (object)['api_request_url' => function() use ($apiUrl) {
-                return $apiUrl;
-            }]
-        ]);
-
-        // Mock WordPress add_query_arg function
-        wp::userFunction('add_query_arg', [
-            'args' => ['secret', $callbackSecret, $apiUrl],
-            'return' => $wordpressCallbackUrl,
-        ]);
-
-        // Directly call the examine_server_callback_urls function
-        $result = $this->blockonomics->examine_server_callback_urls($responseBody, $crypto);
-
-        // Assert the expected error
-        $this->assertEquals('Please add a new store on blockonomics website', $result);
-    }
-
-    public function testExamineServerCallbackUrlsWithNoMatch() {
-        $callbackSecret = 'secret123';
-        $apiUrl = 'https://example.com/wc-api/WC_Gateway_Blockonomics';
-        $wordpressCallbackUrl = $apiUrl . '?secret=' . $callbackSecret;
-        $responseBody = [
-            (object) ['callback' => 'https://otherurl.com', 'address' => 'xpub1'],
-            (object) ['callback' => 'https://anotherurl.com', 'address' => 'xpub2']
-        ];
         $crypto = 'btc';
 
         wp::userFunction('get_option', [
@@ -536,5 +293,5 @@ class BlockonomicsTest extends TestCase {
         wp::tearDown();
         parent::tearDown();
     }
-
 }
+?>


### PR DESCRIPTION
This PR is part 1 of supporting the new user flow in plugin, and making it in line with new Blockonomics Rest API. 
Stuff done:
- Currencies Tab is removed
- Enable BCH is now a checkbox under Advanced Settings (default behavior is unchecked)
- Test Setup doesn't support BCH now
- BCH checkout is still supported if BCH is enabled under Advanced Settings
- Revised unit tests to align with the removal of BCH from the test setup process  