### PR TITLE
Fix - correct url construction for transaction displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wordpress Bitcoin Payments - Blockonomics # 
-**Contributors:** juhasiivikko, darrenwestwood, blockonomics
+**Contributors:** juhasiivikko, darrenwestwood, blockonomics, anktd, btcdeveloper
 **Tags:** bitcoin, accept bitcoin, bitcoin woocommerce, bitcoin wordpress plugin, bitcoin payments
 **Requires at least:** 3.0.1 
 **Tested up to:** 6.6.2
@@ -11,7 +11,7 @@ Accept bitcoin payments and altcoins on your WooCommerce website. Bitcoin paymen
 
 ## Description ## 
 
-The fastest and easiest way to start accepting Bitcoin payments on your WooCommerce online store. Since 2015, [Blockonomics](https://www.blockonomics.co/merchants?utm_source=wordpress) has helped thousands of ecommerce sites increase sales by including Bitcoin and Bitcoin Cash as payment options for their customers. 
+The fastest and easiest way to start accepting Bitcoin payments on your WooCommerce online store. Since 2015, [Blockonomics](https://www.blockonomics.co/merchants?utm_source=wordpress) has helped thousands of ecommerce sites increase sales by including Bitcoin and Bitcoin Cash as payment options for their customers.
 
 ### A truly decentralized bitcoin payment processor for WordPress ### 
 

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -316,21 +316,21 @@ function blockonomics_woocommerce_init()
     function bnomics_display_payment_details($order, $transactions, $email=false)
     {
         $blockonomics = new Blockonomics;
-        
+
         $output  = '<h2 class="woocommerce-column__title">Payment details</h2>';
         $output .= '<table class="woocommerce-table woocommerce-table--order-details shop_table order_details">'; 
         $output .= '<tbody>';
         $total_paid_fiat = $blockonomics->calculate_total_paid_fiat($transactions);
         foreach ($transactions as $transaction) {
-           
-            $base_url = ($transaction['crypto'] === 'btc') ? Blockonomics::BASE_URL : Blockonomics::BCH_BASE_URL;
-            
+
+            $base_url = ($transaction['crypto'] === 'btc') ? Blockonomics::BASE_URL : Blockonomics::BCH_BASE_URL . '/api';
+
             $output .=  '<tr><td scope="row">';
-            $output .=  '<a style="word-wrap: break-word;word-break: break-all;" href="' . $base_url . '/api/tx?txid=' . $transaction['txid'] . '&addr=' . $transaction['address'] . '">' . $transaction['txid'] . '</a></td>';
-            
+            $output .=  '<a style="word-wrap: break-word;word-break: break-all;" href="' . $base_url . '/tx?txid=' . $transaction['txid'] . '&addr=' . $transaction['address'] . '">' . $transaction['txid'] . '</a></td>';
+
             $formatted_paid_fiat = ($transaction['payment_status'] == '2') ? wc_price($transaction['paid_fiat']) : 'Processing';
             $output .= '<td>' . $formatted_paid_fiat . '</td></tr>';
-            
+
         }
         $output .= '</tbody>';
         $expected_fiat = (float)$order->get_total();


### PR DESCRIPTION
Based on issue reported [here](https://blockonomics.freshdesk.com/a/tickets/337983)
Thanks @ARK4579 

Note this PR also contains adding two handles for WordPress forum support required as per forum guidelines