### PR TITLE
Php 8.2 Deprecation Warning Fixes

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -323,11 +323,10 @@ function blockonomics_woocommerce_init()
         $total_paid_fiat = $blockonomics->calculate_total_paid_fiat($transactions);
         foreach ($transactions as $transaction) {
 
-            $base_url = ($transaction['crypto'] === 'btc') ? Blockonomics::BASE_URL : Blockonomics::BCH_BASE_URL . '/api';
+            $base_url = ($transaction['crypto'] === 'btc') ? Blockonomics::BASE_URL . '/#/search?q=' : Blockonomics::BCH_BASE_URL . '/api/tx?txid=';
 
             $output .=  '<tr><td scope="row">';
-            $output .=  '<a style="word-wrap: break-word;word-break: break-all;" href="' . $base_url . '/tx?txid=' . $transaction['txid'] . '&addr=' . $transaction['address'] . '">' . $transaction['txid'] . '</a></td>';
-
+            $output .=  '<a style="word-wrap: break-word;word-break: break-all;" href="' . $base_url . $transaction['txid'] . '&addr=' . $transaction['address'] . '">' . $transaction['txid'] . '</a></td>';
             $formatted_paid_fiat = ($transaction['payment_status'] == '2') ? wc_price($transaction['paid_fiat']) : 'Processing';
             $output .= '<td>' . $formatted_paid_fiat . '</td></tr>';
 

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -91,8 +91,9 @@ function blockonomics_woocommerce_init()
     }
 
     function blockonomics_add_admin_menu() {
+        // Use options.php as parent slug to create a hidden admin page
         add_submenu_page(
-            null,
+            'options.php', // parent slug
             'Blockonomics Setup',
             'Blockonomics',
             'manage_options',

--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -538,7 +538,9 @@ function blockonomics_uninstall_hook() {
     global $wpdb;
     // drop blockonomics_orders & blockonomics_payments on uninstallation
     // blockonomics_orders was the payments table before db version 1.2
-    $wpdb->query($wpdb->prepare("DROP TABLE IF EXISTS ".$wpdb->prefix."blockonomics_orders , ".$wpdb->prefix."blockonomics_payments"));
+    // Fix: Add proper placeholder in the query
+    $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."blockonomics_orders");
+    $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."blockonomics_payments");
     delete_option("blockonomics_db_version");
 
     // Remove the custom page and shortcode added for payment

--- a/composer.lock
+++ b/composer.lock
@@ -46,6 +46,10 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A mocking library to take the pain out of unit testing for WordPress",
+            "support": {
+                "issues": "https://github.com/10up/wp_mock/issues",
+                "source": "https://github.com/10up/wp_mock/tree/master"
+            },
             "time": "2019-03-16T03:44:39+00:00"
         },
         {
@@ -90,6 +94,10 @@
                 "runkit",
                 "testing"
             ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.0"
+            },
             "time": "2024-09-27T16:59:55+00:00"
         },
         {
@@ -142,6 +150,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -203,6 +215,10 @@
             "keywords": [
                 "test"
             ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+            },
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
@@ -279,20 +295,27 @@
                 "test double",
                 "testing"
             ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
             "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -329,13 +352,17 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -392,6 +419,10 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/theseer",
@@ -445,6 +476,10 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
@@ -508,6 +543,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.17"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -564,6 +603,10 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -611,6 +654,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
             "time": "2015-06-21T13:50:34+00:00"
         },
         {
@@ -660,6 +707,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -715,6 +766,10 @@
             "keywords": [
                 "tokenizer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -801,6 +856,11 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.40"
+            },
             "funding": [
                 {
                     "url": "https://phpunit.de/sponsors.html",
@@ -860,6 +920,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -930,6 +994,10 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -992,6 +1060,10 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1051,6 +1123,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1124,6 +1200,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1184,6 +1264,10 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1237,6 +1321,10 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1288,6 +1376,10 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1347,6 +1439,10 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1395,6 +1491,9 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1447,6 +1546,10 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/1.1.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1496,6 +1599,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
@@ -1536,6 +1643,10 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/theseer",
@@ -1547,10 +1658,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -502,20 +502,15 @@ class Blockonomics
     }
 
     public function calculate_order_params($order){
-    
         // Check if order is unused or new
         if ( $order['payment_status'] == 0) {
             return $this->calculate_new_order_params($order);
         }
         if ($order['payment_status'] == 2){
-
             if ($this->is_order_underpaid($order) && $this->is_partial_payments_active()){
-
                 return $this->create_and_insert_new_order_on_underpayment($order);
             }
-
         }
-    
         return $order;
     }
 
@@ -771,7 +766,7 @@ class Blockonomics
     // Check and update the crypto order or create a new order
     public function process_order($order_id, $crypto){
         $order = $this->get_order_by_id_and_crypto($order_id, $crypto);
-        if ($order) {    
+        if ($order) {
             // Update the existing order info
             $order = $this->calculate_order_params($order);
             $this->update_order($order);
@@ -785,7 +780,6 @@ class Blockonomics
             $this->insert_order($order);
             $this->record_address($order_id, $crypto, $order['address']);
         }
-    
         return $order;
     }
 

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -584,8 +584,7 @@ class Blockonomics
             'crypto'             => $crypto,
             'address'            => $address
         );
-        $order = $this->calculate_order_params($order);
-        return $order;
+        return $this->calculate_order_params($order);
     }
 
     public function get_error_context($error_type){

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -5,15 +5,15 @@
  */
 class Blockonomics
 {
-    const BASE_URL = 'https://www.blockonomics.co/api';
-    const STORES_URL = self::BASE_URL . '/v2/stores?wallets=true';
+    const BASE_URL = 'https://www.blockonomics.co';
+    const STORES_URL = self::BASE_URL . '/api/v2/stores?wallets=true';
 
-    const NEW_ADDRESS_URL = self::BASE_URL . '/new_address';
-    const PRICE_URL = 'https://www.blockonomics.co/api/price';
+    const NEW_ADDRESS_URL = self::BASE_URL . '/api/new_address';
+    const PRICE_URL = self::BASE_URL . '/api/price';
 
     const BCH_BASE_URL = 'https://bch.blockonomics.co';
-    const BCH_PRICE_URL = 'https://bch.blockonomics.co/api/price';
-    const BCH_NEW_ADDRESS_URL = 'https://bch.blockonomics.co/api/new_address';
+    const BCH_PRICE_URL = self::BCH_BASE_URL . '/api/price';
+    const BCH_NEW_ADDRESS_URL = self::BCH_BASE_URL . '/api/new_address';
 
 
     function get_order_paid_fiat($order_id) {
@@ -171,7 +171,7 @@ class Blockonomics
 
     private function update_store($store_id, $data) {
         // Ensure we're using the specific store endpoint
-        $url = self::BASE_URL . '/v2/stores/' . $store_id;
+        $url = self::BASE_URL . '/api/v2/stores/' . $store_id;
         return $this->post($url, $this->api_key, wp_json_encode($data), 45);
     }
 

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -502,15 +502,20 @@ class Blockonomics
     }
 
     public function calculate_order_params($order){
+    
         // Check if order is unused or new
         if ( $order['payment_status'] == 0) {
             return $this->calculate_new_order_params($order);
         }
         if ($order['payment_status'] == 2){
+
             if ($this->is_order_underpaid($order) && $this->is_partial_payments_active()){
+
                 return $this->create_and_insert_new_order_on_underpayment($order);
             }
+
         }
+    
         return $order;
     }
 
@@ -766,7 +771,7 @@ class Blockonomics
     // Check and update the crypto order or create a new order
     public function process_order($order_id, $crypto){
         $order = $this->get_order_by_id_and_crypto($order_id, $crypto);
-        if ($order) {
+        if ($order) {    
             // Update the existing order info
             $order = $this->calculate_order_params($order);
             $this->update_order($order);
@@ -780,6 +785,7 @@ class Blockonomics
             $this->insert_order($order);
             $this->record_address($order_id, $crypto, $order['address']);
         }
+    
         return $order;
     }
 

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -66,8 +66,9 @@ class Blockonomics
     }
 
 
-    public function new_address($secret, $crypto, $reset=false)
+    public function new_address($crypto, $reset=false)
     {
+        $secret = get_option("blockonomics_callback_secret");
         // Get the full callback URL
         $api_url = WC()->api_request_url('WC_Gateway_Blockonomics');
         $callback_url = add_query_arg('secret', $secret, $api_url);
@@ -573,7 +574,7 @@ class Blockonomics
     }
 
     public function create_new_order($order_id, $crypto){
-        $responseObj = $this->new_address(get_option("blockonomics_callback_secret"), $crypto);
+        $responseObj = $this->new_address($crypto);
         if($responseObj->response_code != 200) {
             return array("error"=>$responseObj->response_message);
         }

--- a/php/class-blockonomics-setup.php
+++ b/php/class-blockonomics-setup.php
@@ -9,6 +9,7 @@ if (!defined('ABSPATH')) {
 }
 
 class Blockonomics_Setup {
+    private $api_key;
     private function get_callback_url() {
         $callback_secret = get_option('blockonomics_callback_secret');
         $api_url = WC()->api_request_url('WC_Gateway_Blockonomics');

--- a/php/class-blockonomics-setup.php
+++ b/php/class-blockonomics-setup.php
@@ -54,7 +54,7 @@ class Blockonomics_Setup {
 
     public function check_store_setup() {
         $api_key = get_option('blockonomics_api_key');
-        $stores_url = Blockonomics::BASE_URL . '/v2/stores?wallets=true';
+        $stores_url = Blockonomics::BASE_URL . '/api/v2/stores?wallets=true';
         $response = wp_remote_get($stores_url, array(
             'headers' => array(
                 'Authorization' => 'Bearer ' . $this->api_key,
@@ -85,7 +85,7 @@ class Blockonomics_Setup {
                 $store_base_url = preg_replace('/https?:\/\//', '', $store->http_callback);
                 if (strpos($store_base_url, $base_url) === 0) {
                     $response = wp_remote_post(
-                        Blockonomics::BASE_URL . '/v2/stores/' . $partial_match_store->id,
+                        Blockonomics::BASE_URL . '/api/v2/stores/' . $partial_match_store->id,
                         array(
                             'headers' => array(
                                 'Authorization' => 'Bearer ' . $this->api_key,
@@ -122,7 +122,7 @@ class Blockonomics_Setup {
             'http_callback' => $callback_url
         );
         $response = wp_remote_post(
-            Blockonomics::BASE_URL . '/v2/stores',
+            Blockonomics::BASE_URL . '/api/v2/stores',
             array(
                 'headers' => array(
                     'Authorization' => 'Bearer ' . $api_key,
@@ -144,7 +144,7 @@ class Blockonomics_Setup {
 
                 // Step 2: Attach wallet to store
                 $wallet_attach_response = wp_remote_post(
-                    Blockonomics::BASE_URL . '/v2/stores/' . $store_id . '/wallets',
+                    Blockonomics::BASE_URL . '/api/v2/stores/' . $store_id . '/wallets',
                     array(
                         'headers' => array(
                             'Authorization' => 'Bearer ' . $api_key,

--- a/tests/BlockonomicsTest.php
+++ b/tests/BlockonomicsTest.php
@@ -10,6 +10,7 @@ class TestableBlockonomics extends Blockonomics {
 }
 
 class BlockonomicsTest extends TestCase {
+        protected $blockonomics;
 
     protected function setUp(): void {
         parent::setUp();

--- a/tests/BlockonomicsTest.php
+++ b/tests/BlockonomicsTest.php
@@ -10,7 +10,7 @@ class TestableBlockonomics extends Blockonomics {
 }
 
 class BlockonomicsTest extends TestCase {
-        protected $blockonomics;
+    protected $blockonomics;
 
     protected function setUp(): void {
         parent::setUp();


### PR DESCRIPTION
Recently a bug was reported about deprecated warning on installing the Blockonomics plugin -> Ticket [here](https://blockonomics.freshdesk.com/a/tickets/338040).

**Fix**: Changed the parent slug in `add_submenu_page()` from empty string to `'options.php'` to resolve PHP 8.1 deprecation warnings while maintaining hidden menu functionality ➞ f7784a375b621ce1b84c0de3e1457ea515a68814

- Before this, we were using `null`:
  - Using it caused PHP 8.1 deprecation warnings in WordPress core functions
  - Specifically triggers warnings in:
     - `strpos()`: When WordPress checks menu hierarchy
     - `str_replace()`: During menu slug processing
   - This occurs because WordPress core functions expect string types but receive null
- Using empty string (`''`) (as the suggested fix by user report): 
   - Resolves the initial strpos/str_replace warnings
   - However, triggers new deprecation warning in `strip_tags()`
   - This happens because WordPress internally converts empty string to null during menu processing
   - The conversion occurs before the string reaches admin-header.php
- Using `'options.php'`:
   - References WordPress core options handling system
   - Maintains proper string type throughout WordPress menu processing
   - Prevents type coercion issues that lead to deprecation warnings
   - Standard WordPress pattern for hidden admin pages
   - Doesn't create visible menu items while ensuring proper page registration
---

Other fixes in this PR:

- Remove incorrect `wpdb::prepare` usage in uninstall hook by removing unnecessary prepare call for static queries ➞ 20fa4549d7a8a9d73e159fe5be00823daa73a0d6

- Added explicit property declaration `private $api_key;` to the Blockonomics_Setup class to comply with PHP 8.2's deprecation of dynamic properties ➞ 573320a79dbcc5f0263c255b8adfcdabee85b6da
