### PR TITLE
[Fix] 0 discount shown on some themes

### DIFF
--- a/blockonomics-woocommerce.php
+++ b/blockonomics-woocommerce.php
@@ -226,9 +226,11 @@ function blockonomics_woocommerce_init()
         }
     
         $discount = $cart->get_subtotal() * ( $discount_percent / 100 );
-        $cart->add_fee( __( 'Payment Method Discount', 'blockonomics-bitcoin-payments' ), -$discount, false );
+        if ( $discount > 0 ) {
+            $cart->add_fee( __( 'Payment Method Discount', 'blockonomics-bitcoin-payments' ), -$discount, false );
+        }
     }
-    
+
 
     /**
      * Redriect to the checkout page  

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -531,10 +531,10 @@ class Blockonomics
         $results = $wpdb->get_results($query,ARRAY_A);
         $paid_fiat = $this->calculate_total_paid_fiat($results);
         $discount_percent = floatval( get_option( 'blockonomics_bitcoin_discount', 0 ) );
-        $subtotal = (float) $wc_order->get_subtotal();
+        $total = (float) $wc_order->get_total();
         
         // Calculate the expected amount after applying the Bitcoin discount
-        $expected_fiat = $subtotal - ( $subtotal * ( $discount_percent / 100 ) );
+        $expected_fiat = $total - ( $total * ( $discount_percent / 100 ) );
         
         $order['expected_fiat'] = $expected_fiat - $paid_fiat;
         $order['currency'] = get_woocommerce_currency();

--- a/php/Blockonomics.php
+++ b/php/Blockonomics.php
@@ -531,10 +531,11 @@ class Blockonomics
         $results = $wpdb->get_results($query,ARRAY_A);
         $paid_fiat = $this->calculate_total_paid_fiat($results);
         $discount_percent = floatval( get_option( 'blockonomics_bitcoin_discount', 0 ) );
+        $subtotal = (float) $wc_order->get_subtotal();
         $total = (float) $wc_order->get_total();
         
         // Calculate the expected amount after applying the Bitcoin discount
-        $expected_fiat = $total - ( $total * ( $discount_percent / 100 ) );
+        $expected_fiat = $total - ( $subtotal * ( $discount_percent / 100 ) );
         
         $order['expected_fiat'] = $expected_fiat - $paid_fiat;
         $order['currency'] = get_woocommerce_currency();


### PR DESCRIPTION
Markite theme is showing the Payment Method Discount text on checkout, even when it's set to 0.

I've added a check to apply the [add_fee](https://wp-kama.com/plugin/woocommerce/function/WC_Cart::add_fee) method only when discount > 0

![image](https://github.com/user-attachments/assets/5d3263fc-c288-4bc6-bcc5-c8b21e3647ba)
